### PR TITLE
Clean up unused providers code

### DIFF
--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -26,10 +26,7 @@ import { ModuleSubmoduleResources } from "./routes/ModuleSubmodule/resources";
 import { Provider } from "./routes/Provider";
 import { ProviderDocs } from "./routes/Provider/Docs";
 import { ProviderOverview } from "./routes/Provider/Overview";
-import {
-  namespaceProvidersLoader,
-  providersLoader,
-} from "./routes/Providers/loader";
+import { providersLoader } from "./routes/Providers/loader";
 import { providerOverviewLoader } from "./routes/Provider/Overview/loader";
 import { providerDocsLoader } from "./routes/Provider/Docs/loader";
 import { providerLoader } from "./routes/Provider/loader";
@@ -43,6 +40,7 @@ import { moduleExampleReadmeLoader } from "./routes/ModuleExample/Readme/loader"
 import { ModuleRouteContext } from "./routes/Module/types";
 import { moduleExampleMiddleware } from "./routes/ModuleExample/middleware";
 import { ModuleExampleRouteContext } from "./routes/ModuleExample/types";
+import { ProviderRouteContext } from "./routes/Provider/types";
 
 export const router = createBrowserRouter(
   [
@@ -241,12 +239,7 @@ export const router = createBrowserRouter(
           children: [
             {
               index: true,
-              element: <Providers />,
-              loader: namespaceProvidersLoader,
-              handle: {
-                crumb: ({ namespace }) =>
-                  createCrumb(`/provider/${namespace}`, namespace),
-              },
+              element: <Navigate to="/providers" />,
             },
             {
               path: ":provider/:version?",
@@ -254,12 +247,15 @@ export const router = createBrowserRouter(
               loader: providerLoader,
               handle: {
                 middleware: providerMiddleware,
-                crumb: ({ namespace, provider, version }) => [
+                crumb: ({
+                  namespace,
+                  provider,
+                  version,
+                }: ProviderRouteContext) =>
                   createCrumb(
                     `/provider/${namespace}/${provider}/${version}`,
                     `${namespace}/${provider}`,
                   ),
-                ],
               },
               children: [
                 {

--- a/frontend/src/routes/Provider/loader.ts
+++ b/frontend/src/routes/Provider/loader.ts
@@ -14,7 +14,5 @@ export const providerLoader: LoaderFunction = async ({ params }, context) => {
 
   return defer({
     versionData,
-    namespace: params.namespace,
-    provider: params.provider,
   });
 };

--- a/frontend/src/routes/Provider/middleware.ts
+++ b/frontend/src/routes/Provider/middleware.ts
@@ -7,16 +7,22 @@ export const providerMiddleware: LoaderFunction = async (
   { params },
   context,
 ) => {
+  const { namespace, provider, version } = params;
+
   const data = await queryClient.ensureQueryData(
-    getProviderDataQuery(params.namespace, params.provider),
+    getProviderDataQuery(namespace, provider),
   );
 
   const [latestVersion] = data.versions;
 
-  if (params.version === latestVersion.id || !params.version) {
-    return redirect(`/provider/${params.namespace}/${params.provider}/latest`);
+  if (version === latestVersion.id || !version) {
+    return redirect(`/provider/${namespace}/${provider}/latest`);
   }
 
-  (context as ProviderRouteContext).version =
-    params.version === "latest" ? latestVersion.id : params.version;
+  const providerContext = context as ProviderRouteContext;
+
+  providerContext.version = version === "latest" ? latestVersion.id : version;
+  providerContext.rawVersion = version;
+  providerContext.namespace = namespace;
+  providerContext.provider = provider;
 };

--- a/frontend/src/routes/Provider/types.ts
+++ b/frontend/src/routes/Provider/types.ts
@@ -1,3 +1,6 @@
 export interface ProviderRouteContext {
   version: string;
+  rawVersion: string;
+  namespace: string | undefined;
+  provider: string | undefined;
 }

--- a/frontend/src/routes/Providers/loader.ts
+++ b/frontend/src/routes/Providers/loader.ts
@@ -1,19 +1,8 @@
-import { defer, LoaderFunction } from "react-router-dom";
+import { defer } from "react-router-dom";
 import { queryClient } from "../../query";
-import { getNamespaceProvidersQuery, getProvidersQuery } from "./query";
+import { getProvidersQuery } from "./query";
 
 export const providersLoader = () => {
   const index = queryClient.ensureQueryData(getProvidersQuery());
   return defer({ index });
-};
-
-export const namespaceProvidersLoader: LoaderFunction = ({ params }) => {
-  const index = queryClient.ensureQueryData(
-    getNamespaceProvidersQuery(params.namespace),
-  );
-
-  return {
-    index,
-    namespace: params.namespace,
-  };
 };

--- a/frontend/src/routes/Providers/query.ts
+++ b/frontend/src/routes/Providers/query.ts
@@ -14,19 +14,3 @@ export const getProvidersQuery = () =>
       return res.providers as definitions["ProviderList"]["providers"];
     },
   });
-
-export const getNamespaceProvidersQuery = (namespace: string | undefined) =>
-  queryOptions({
-    queryKey: ["namespace-providers", namespace],
-    queryFn: async () => {
-      // TODO: Handle fetching providers by individual namespace
-      // For now this is commented out until we have a better understanding of how to handle this
-      // const response = await fetch(
-      //   `${import.meta.env.VITE_DATA_API_URL}/mega_index.json`,
-      // );
-
-      // const res = await response.json();
-
-      return [];
-    },
-  });


### PR DESCRIPTION
This PR removes unused queries and route code that did nothing else than displaying the same list as on the main `/providers` page. I also added a few fields to the route context so they can be accessed by breadcrumbs without having to expose them from each loader.