### PR TITLE
Make header static

### DIFF
--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -7,14 +7,10 @@ import { ThemeSwitcher } from "./ThemeSwitcher";
 
 export function Header() {
   return (
-    <header className="sticky top-0 z-10 flex h-20 items-center border-b border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-blue-950">
+    <header className="flex h-20 items-center border-b border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-blue-950">
       <div className="mx-auto flex w-full max-w-screen-3xl items-end px-5">
         <h1 className="flex items-end">
-          <a
-            href="/"
-            aria-label="Home"
-            target="_blank"
-          >
+          <a href="/" aria-label="Home" target="_blank">
             <HeaderLogo />
           </a>
           <span className="text-2xl tracking-wide">Registry</span>

--- a/frontend/src/components/SidebarPanel/index.tsx
+++ b/frontend/src/components/SidebarPanel/index.tsx
@@ -10,7 +10,7 @@ export function SidebarPanel({ children, className }: SidebarPanelProps) {
   return (
     <aside
       className={clsx(
-        "sticky top-20 flex max-h-[calc(100vh-theme(height.20)-1px)] w-1/5 min-w-80 shrink-0 flex-col overflow-y-auto [scrollbar-width:thin]",
+        "sticky top-0 flex max-h-screen w-1/5 min-w-80 shrink-0 flex-col overflow-y-auto [scrollbar-width:thin]",
         className,
       )}
     >


### PR DESCRIPTION
This PR aligns the behavior with what's done on the main OpenTofu website, where header is static and only sidebars are sticky/floating. It's done mainly to simplify the logic that currently requires calculating the heights of the sidebar panels using the height of the header.

If we want, there's another approach that would allow sticky header with no funky heights for sidebars, but the main scrollbar would be moved inside the main column.