### PR TITLE
Clean up providers list

### DIFF
--- a/frontend/src/components/Button/index.tsx
+++ b/frontend/src/components/Button/index.tsx
@@ -1,17 +1,22 @@
-import { MouseEventHandler, ReactNode } from "react";
+import { AnchorHTMLAttributes, ButtonHTMLAttributes, ReactNode } from "react";
 import clsx from "clsx";
 import { Link } from "react-router-dom";
 
-interface RouterLinkProps {
+type BaseLinkProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href">;
+
+interface RouterLinkProps extends BaseLinkProps {
+  href?: never;
   to: string;
 }
 
-interface NativeLinkProps {
+interface NativeLinkProps extends BaseLinkProps {
   href: string;
+  to?: never;
 }
 
-interface NativeButtonProps {
-  onClick: MouseEventHandler<HTMLButtonElement>;
+interface NativeButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  href?: never;
+  to?: never;
 }
 
 type InteractionProps = RouterLinkProps | NativeLinkProps | NativeButtonProps;
@@ -34,7 +39,7 @@ export function Button({ children, variant, className, ...rest }: ButtonProps) {
     className,
   );
 
-  if ("to" in rest && rest.to) {
+  if ("to" in rest && rest.to !== undefined) {
     return (
       <Link {...rest} className={computedClassName}>
         {children}
@@ -42,7 +47,7 @@ export function Button({ children, variant, className, ...rest }: ButtonProps) {
     );
   }
 
-  if ("href" in rest && rest.href) {
+  if ("href" in rest && rest.href !== undefined) {
     return (
       <a {...rest} className={computedClassName}>
         {children}

--- a/frontend/src/components/SimpleLayout/index.tsx
+++ b/frontend/src/components/SimpleLayout/index.tsx
@@ -10,7 +10,7 @@ export function SimpleLayout({ children }: SimpleLayoutProps) {
   return (
     <>
       <Header />
-      <main className="mx-auto flex w-full max-w-screen-3xl grow flex-col px-5">
+      <main className="mx-auto flex w-full max-w-screen-3xl grow flex-col px-5 pb-5">
         <Breadcrumbs />
         {children}
       </main>

--- a/frontend/src/routes/Providers/components/CardItem.tsx
+++ b/frontend/src/routes/Providers/components/CardItem.tsx
@@ -48,12 +48,11 @@ export function ProvidersCardItemSkeleton() {
     <CardItem>
       <span className="flex h-em w-48 animate-pulse bg-gray-500/25 text-xl" />
 
-      <span className="mt-1 flex h-em w-96 animate-pulse bg-gray-500/25" />
+      <span className="mt-5 flex h-em w-96 animate-pulse bg-gray-500/25" />
 
-      <span className="mt-8 flex gap-10">
+      <span className="mt-7 flex gap-10">
         <span className="flex h-em w-36 animate-pulse bg-gray-500/25" />
         <span className="flex h-em w-52 animate-pulse bg-gray-500/25" />
-        <span className="ml-auto flex h-em w-32 animate-pulse bg-gray-500/25" />
       </span>
     </CardItem>
   );

--- a/frontend/src/routes/Providers/components/List.tsx
+++ b/frontend/src/routes/Providers/components/List.tsx
@@ -1,37 +1,52 @@
-import { ProvidersCardItem } from "./CardItem";
+import { ProvidersCardItem, ProvidersCardItemSkeleton } from "./CardItem";
 
 import { Virtuoso } from "react-virtuoso";
-import { forwardRef } from "react";
+import { ComponentProps, forwardRef } from "react";
 
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { getProvidersQuery } from "../query";
+
+const ProvidersListWrapper = forwardRef<HTMLDivElement, ComponentProps<"div">>(
+  function ProvidersListWrapperImpl({ children, ...props }, ref) {
+    return (
+      <div ref={ref} className="flex flex-col gap-3" {...props}>
+        {children}
+      </div>
+    );
+  },
+);
 
 export function ProvidersList() {
   const { data: providers } = useSuspenseQuery(getProvidersQuery());
 
   return (
-    <>
-      <Virtuoso
-        className="z-0 grow"
-        useWindowScroll
-        data={providers}
-        totalCount={providers.length}
-        components={{
-          List: forwardRef(({ children, ...props }, ref) => (
-            <div ref={ref} className="flex flex-col gap-3" {...props}>
-              {children}
-            </div>
-          )),
-        }}
-        itemContent={(_, provider) => (
-          <ProvidersCardItem
-            key={provider.addr.namespace + provider.addr.name}
-            addr={provider.addr}
-            description={provider.description}
-            latestVersion={provider.versions[0]}
-          />
-        )}
-      />
-    </>
+    <Virtuoso
+      useWindowScroll
+      data={providers}
+      totalCount={providers.length}
+      components={{
+        List: ProvidersListWrapper,
+      }}
+      itemContent={(_, provider) => (
+        <ProvidersCardItem
+          key={provider.addr.namespace + provider.addr.name}
+          addr={provider.addr}
+          description={provider.description}
+          latestVersion={provider.versions[0]}
+        />
+      )}
+    />
+  );
+}
+
+export function ProvidersListSkeleton() {
+  return (
+    <ProvidersListWrapper>
+      <ProvidersCardItemSkeleton />
+      <ProvidersCardItemSkeleton />
+      <ProvidersCardItemSkeleton />
+      <ProvidersCardItemSkeleton />
+      <ProvidersCardItemSkeleton />
+    </ProvidersListWrapper>
   );
 }

--- a/frontend/src/routes/Providers/index.tsx
+++ b/frontend/src/routes/Providers/index.tsx
@@ -5,8 +5,7 @@ import { SimpleLayout } from "@/components/SimpleLayout";
 
 import { Suspense } from "react";
 
-import { ProvidersList } from "./components/List";
-import { ProvidersCardItemSkeleton } from "./components/CardItem";
+import { ProvidersList, ProvidersListSkeleton } from "./components/List";
 
 export function Providers() {
   return (
@@ -15,25 +14,21 @@ export function Providers() {
         <div className="flex flex-col gap-5">
           <PageTitle>Providers</PageTitle>
           <Paragraph>
-              Providers are plugins to OpenTofu and create or destroy resources using their backing API based on your OpenTofu configuration.
+            Providers are plugins to OpenTofu and create or destroy resources
+            using their backing API based on your OpenTofu configuration.
           </Paragraph>
         </div>
-        <Button variant="primary" href="https://opentofu.org">
+        <Button
+          target="_blank"
+          rel="noopener noreferrer"
+          variant="primary"
+          href="https://github.com/opentofu/registry/issues/new?assignees=&labels=provider%2Csubmission&projects=&template=provider.yml&title=Provider%3A+"
+        >
           Add provider
         </Button>
       </div>
 
-      <Suspense
-        fallback={
-          <div className="flex flex-col gap-3">
-            <ProvidersCardItemSkeleton />
-            <ProvidersCardItemSkeleton />
-            <ProvidersCardItemSkeleton />
-            <ProvidersCardItemSkeleton />
-            <ProvidersCardItemSkeleton />
-          </div>
-        }
-      >
+      <Suspense fallback={<ProvidersListSkeleton />}>
         <ProvidersList />
       </Suspense>
     </SimpleLayout>


### PR DESCRIPTION
Changelog:
- slightly cleaned up types in the `Button` component
- synced provider's card item skeleton with the hydrated variant
- added bottom padding to the simple layout, so that the list has consistent spacing around
- changed the link to add a provider to registry – I'll probably move both "add provider" and "add module" links into a single `config.ts` file
- moved the list skeleton closer to the component and extracted shared wrapper into a separate component