### PR TITLE
Handle broken code blocks in MD

### DIFF
--- a/frontend/src/components/Markdown/Pre.tsx
+++ b/frontend/src/components/Markdown/Pre.tsx
@@ -2,9 +2,16 @@ import { HTMLAttributes, ReactElement } from "react";
 import { Code } from "../Code";
 
 export function MarkdownPre({ children }: HTMLAttributes<HTMLPreElement>) {
-  if (!children) return null;
+  if (!children) {
+    return null;
+  }
 
   const child = children as ReactElement;
+
+  if (!child.props.children) {
+    return null;
+  }
+
   const language = child.props.className?.match(/language-(\w+)/)?.[1];
 
   return (


### PR DESCRIPTION
I've noticed some broken code blocks in MD of some providers which causes the page to crash. For context, GH's doesn't handle it either, it just displays an empty code block:

![Screenshot 2024-08-22 at 16 20 22](https://github.com/user-attachments/assets/68859b93-50ea-4ab4-823b-a0d077254fe9)

It seems like the auto-generation of CDKTF docs cannot handle code blocks in lists and nesting gets broken.