### PR TITLE
Filter out special chars from search query

### DIFF
--- a/frontend/src/components/Header/hooks/useGroupedResults.tsx
+++ b/frontend/src/components/Header/hooks/useGroupedResults.tsx
@@ -32,6 +32,10 @@ const parseRef = (ref: string): SearchRef => {
   return JSON.parse(ref);
 };
 
+const filterQuery = (query: string) => {
+  return query.replace(/:/g, "").replace(/\^/g, "");
+};
+
 const useGroupedResults = (
   deferredQuery: string,
   data: Index | undefined,
@@ -41,7 +45,7 @@ const useGroupedResults = (
       return new Map();
     }
 
-    const results = data.search(deferredQuery).slice(0, 10);
+    const results = data.search(filterQuery(deferredQuery)).slice(0, 10);
 
     const groupedResults: Map<
       string,


### PR DESCRIPTION
Seems like lunr.js doesn't have an easy/obvious way to disable the special characters in the search query. This PR disables 2 problematic ones and partially addresses #48 