### PR TITLE
Handle missing licence in UI

### DIFF
--- a/frontend/src/components/RepoMetadataSidebarBlock/index.tsx
+++ b/frontend/src/components/RepoMetadataSidebarBlock/index.tsx
@@ -1,0 +1,74 @@
+import {
+  MetadataSidebarBlock,
+  MetadataSidebarBlockItem,
+} from "../MetadataSidebarBlock";
+import { github } from "@/icons/github";
+import { document } from "@/icons/document";
+import { ReactNode } from "react";
+import { definitions } from "@/api";
+
+function getLinkLabel(url: string) {
+  const match = url.match(/github\.com\/([^/]+)\/([^/]+)/);
+
+  if (!match) {
+    return null;
+  }
+
+  return `${match[1]}/${match[2]}`;
+}
+
+interface BlockProps {
+  license?: definitions["LicenseList"];
+  link?: string | undefined;
+}
+
+export function RepoMetadataSidebarBlock(props: BlockProps) {
+  let license: ReactNode = (
+    <span className="flex h-em w-24 animate-pulse bg-gray-500/25" />
+  );
+
+  if (props.license !== undefined) {
+    license =
+      props.license === null
+        ? "Unavailable"
+        : props.license.map((license) => (
+            <a
+              href={license.link}
+              key={license.spdx}
+              className="underline"
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+              {license.spdx}
+            </a>
+          ));
+  }
+
+  const link = props.link ? (
+    <a
+      href={props.link}
+      className="underline"
+      target="_blank"
+      rel="noreferrer noopener"
+    >
+      {getLinkLabel(props.link)}
+    </a>
+  ) : (
+    <span className="flex h-em w-32 animate-pulse bg-gray-500/25" />
+  );
+
+  return (
+    <MetadataSidebarBlock title="Repository">
+      <MetadataSidebarBlockItem icon={document} title="License">
+        {license}
+      </MetadataSidebarBlockItem>
+      <MetadataSidebarBlockItem icon={github} title="GitHub">
+        {link}
+      </MetadataSidebarBlockItem>
+    </MetadataSidebarBlock>
+  );
+}
+
+export function RepoMetadataSidebarBlockSkeleton() {
+  return <RepoMetadataSidebarBlock />;
+}

--- a/frontend/src/routes/Module/components/MetadataSidebarBlock.tsx
+++ b/frontend/src/routes/Module/components/MetadataSidebarBlock.tsx
@@ -1,66 +1,11 @@
-import {
-  MetadataSidebarBlock,
-  MetadataSidebarBlockItem,
-} from "@/components/MetadataSidebarBlock";
-import { github } from "@/icons/github";
-import { document } from "@/icons/document";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { getModuleVersionDataQuery } from "../query";
 import { useModuleParams } from "../hooks/useModuleParams";
-import { definitions } from "@/api";
 
-function getLinkLabel(url: string) {
-  const match = url.match(/github\.com\/([^/]+)\/([^/]+)/);
-
-  if (!match) {
-    return null;
-  }
-
-  return `${match[1]}/${match[2]}`;
-}
-
-interface BlockProps {
-  license?: definitions["LicenseList"];
-  link?: string | undefined;
-}
-
-function Block(props: BlockProps) {
-  return (
-    <MetadataSidebarBlock title="Repository">
-      <MetadataSidebarBlockItem icon={document} title="License">
-        {props.license ? (
-          props.license.map((license) => (
-            <a
-              href={license.link}
-              key={license.spdx}
-              className="underline"
-              target="_blank"
-              rel="noreferrer noopener"
-            >
-              {license.spdx}
-            </a>
-          ))
-        ) : (
-          <span className="flex h-em w-24 animate-pulse bg-gray-500/25" />
-        )}
-      </MetadataSidebarBlockItem>
-      <MetadataSidebarBlockItem icon={github} title="GitHub">
-        {props.link ? (
-          <a
-            href={props.link}
-            className="underline"
-            target="_blank"
-            rel="noreferrer noopener"
-          >
-            {getLinkLabel(props.link)}
-          </a>
-        ) : (
-          <span className="flex h-em w-32 animate-pulse bg-gray-500/25" />
-        )}
-      </MetadataSidebarBlockItem>
-    </MetadataSidebarBlock>
-  );
-}
+import {
+  RepoMetadataSidebarBlock,
+  RepoMetadataSidebarBlockSkeleton,
+} from "@/components/RepoMetadataSidebarBlock";
 
 export function ModuleMetadataSidebarBlock() {
   const { namespace, name, target, version } = useModuleParams();
@@ -69,9 +14,7 @@ export function ModuleMetadataSidebarBlock() {
     getModuleVersionDataQuery(namespace, name, target, version),
   );
 
-  return <Block license={data.licenses} link={data.link} />;
+  return <RepoMetadataSidebarBlock license={data.licenses} link={data.link} />;
 }
 
-export function ModuleMetadataSidebarBlockSkeleton() {
-  return <Block />;
-}
+export { RepoMetadataSidebarBlockSkeleton as ModuleMetadataSidebarBlockSkeleton };

--- a/frontend/src/routes/Provider/components/MetadataSidebarBlock.tsx
+++ b/frontend/src/routes/Provider/components/MetadataSidebarBlock.tsx
@@ -1,67 +1,11 @@
-import {
-  MetadataSidebarBlock,
-  MetadataSidebarBlockItem,
-} from "@/components/MetadataSidebarBlock";
-
-import { github } from "@/icons/github";
-import { document } from "@/icons/document";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { getProviderVersionDataQuery } from "../query";
 import { useProviderParams } from "../hooks/useProviderParams";
-import { definitions } from "@/api";
 
-function getLinkLabel(url: string) {
-  const match = url.match(/github\.com\/([^/]+)\/([^/]+)/);
-
-  if (!match) {
-    return null;
-  }
-
-  return `${match[1]}/${match[2]}`;
-}
-
-interface BlockProps {
-  license?: definitions["LicenseList"];
-  link?: string | undefined;
-}
-
-function Block(props: BlockProps) {
-  return (
-    <MetadataSidebarBlock title="Repository">
-      <MetadataSidebarBlockItem icon={document} title="License">
-        {props.license ? (
-          props.license.map((license) => (
-            <a
-              href={license.link}
-              key={license.spdx}
-              className="underline"
-              target="_blank"
-              rel="noreferrer noopener"
-            >
-              {license.spdx}
-            </a>
-          ))
-        ) : (
-          <span className="flex h-em w-24 animate-pulse bg-gray-500/25" />
-        )}
-      </MetadataSidebarBlockItem>
-      <MetadataSidebarBlockItem icon={github} title="GitHub">
-        {props.link ? (
-          <a
-            href={props.link}
-            className="underline"
-            target="_blank"
-            rel="noreferrer noopener"
-          >
-            {getLinkLabel(props.link)}
-          </a>
-        ) : (
-          <span className="flex h-em w-32 animate-pulse bg-gray-500/25" />
-        )}
-      </MetadataSidebarBlockItem>
-    </MetadataSidebarBlock>
-  );
-}
+import {
+  RepoMetadataSidebarBlock,
+  RepoMetadataSidebarBlockSkeleton,
+} from "@/components/RepoMetadataSidebarBlock";
 
 export function ProviderMetadataSidebarBlock() {
   const { namespace, provider, version } = useProviderParams();
@@ -70,9 +14,7 @@ export function ProviderMetadataSidebarBlock() {
     getProviderVersionDataQuery(namespace, provider, version),
   );
 
-  return <Block license={data.license} link={data.link} />;
+  return <RepoMetadataSidebarBlock license={data.license} link={data.link} />;
 }
 
-export function ProviderMetadataSidebarBlockSkeleton() {
-  return <Block />;
-}
+export { RepoMetadataSidebarBlockSkeleton as ProviderMetadataSidebarBlockSkeleton };


### PR DESCRIPTION
Fixes #63

Preview: https://handle-missing-licence.registry-ui-dxi.pages.dev/module/hashicorp/terraform-cloud-operator/kubernetes/latest