### PR TITLE
Tweak spacings in MD content

### DIFF
--- a/frontend/src/components/Markdown/H1.tsx
+++ b/frontend/src/components/Markdown/H1.tsx
@@ -7,7 +7,7 @@ export function MarkdownH1({
 }: HTMLAttributes<HTMLHeadingElement>) {
   return (
     <h3
-      className="group mt-8 scroll-mt-28 break-words text-4xl font-bold first:mt-0"
+      className="group mt-8 scroll-mt-5 break-words text-4xl font-bold first:mt-0"
       id={id}
     >
       {children}

--- a/frontend/src/components/Markdown/H1.tsx
+++ b/frontend/src/components/Markdown/H1.tsx
@@ -6,7 +6,10 @@ export function MarkdownH1({
   id,
 }: HTMLAttributes<HTMLHeadingElement>) {
   return (
-    <h3 className="group scroll-mt-28 break-words font-bold text-4xl" id={id}>
+    <h3
+      className="group mt-8 scroll-mt-28 break-words text-4xl font-bold first:mt-0"
+      id={id}
+    >
       {children}
       {id && <HeadingLink id={id} label={children as string} />}
     </h3>

--- a/frontend/src/components/Markdown/H2.tsx
+++ b/frontend/src/components/Markdown/H2.tsx
@@ -7,7 +7,7 @@ export function MarkdownH2({
 }: HTMLAttributes<HTMLHeadingElement>) {
   return (
     <h4
-      className="group mt-8 scroll-mt-28 break-words text-3xl font-bold first:mt-0"
+      className="group mt-8 scroll-mt-5 break-words text-3xl font-bold first:mt-0"
       id={id}
     >
       {children}

--- a/frontend/src/components/Markdown/H2.tsx
+++ b/frontend/src/components/Markdown/H2.tsx
@@ -7,7 +7,7 @@ export function MarkdownH2({
 }: HTMLAttributes<HTMLHeadingElement>) {
   return (
     <h4
-      className="group mt-8 scroll-mt-28 break-words font-bold text-3xl"
+      className="group mt-8 scroll-mt-28 break-words text-3xl font-bold first:mt-0"
       id={id}
     >
       {children}

--- a/frontend/src/components/Markdown/H3.tsx
+++ b/frontend/src/components/Markdown/H3.tsx
@@ -7,7 +7,7 @@ export function MarkdownH3({
 }: HTMLAttributes<HTMLHeadingElement>) {
   return (
     <h5
-      className="group mt-8 scroll-mt-28 break-words text-xl font-bold first:mt-0"
+      className="group mt-8 scroll-mt-5 break-words text-xl font-bold first:mt-0"
       id={id}
     >
       {children}

--- a/frontend/src/components/Markdown/H3.tsx
+++ b/frontend/src/components/Markdown/H3.tsx
@@ -7,7 +7,7 @@ export function MarkdownH3({
 }: HTMLAttributes<HTMLHeadingElement>) {
   return (
     <h5
-      className="group mt-8 scroll-mt-28 break-words font-bold text-xl"
+      className="group mt-8 scroll-mt-28 break-words text-xl font-bold first:mt-0"
       id={id}
     >
       {children}

--- a/frontend/src/components/Markdown/Li.tsx
+++ b/frontend/src/components/Markdown/Li.tsx
@@ -1,5 +1,9 @@
 import { HTMLAttributes } from "react";
 
 export function MarkdownLi({ children }: HTMLAttributes<HTMLLIElement>) {
-  return <li className="text-gray-700 dark:text-gray-300">{children}</li>;
+  return (
+    <li className="pl-2 leading-7 text-gray-700 dark:text-gray-300 [&+&]:mt-2.5">
+      {children}
+    </li>
+  );
 }

--- a/frontend/src/components/Markdown/Ol.tsx
+++ b/frontend/src/components/Markdown/Ol.tsx
@@ -2,6 +2,8 @@ import { HTMLAttributes } from "react";
 
 export function MarkdownOl({ children }: HTMLAttributes<HTMLUListElement>) {
   return (
-    <ol className="my-4 ml-8 flex list-decimal flex-col gap-2">{children}</ol>
+    <ol className="ml-8 mt-5 flex list-decimal flex-col gap-2 [li>&]:mt-2.5">
+      {children}
+    </ol>
   );
 }

--- a/frontend/src/components/Markdown/P.tsx
+++ b/frontend/src/components/Markdown/P.tsx
@@ -2,5 +2,9 @@ import { HTMLAttributes } from "react";
 import { Paragraph } from "../Paragraph";
 
 export function MarkdownP({ children }: HTMLAttributes<HTMLParagraphElement>) {
-  return <Paragraph className="mt-5">{children}</Paragraph>;
+  return (
+    <Paragraph className="mt-5 leading-7 [li>&:first-child]:mt-0">
+      {children}
+    </Paragraph>
+  );
 }

--- a/frontend/src/components/Markdown/Ul.tsx
+++ b/frontend/src/components/Markdown/Ul.tsx
@@ -2,6 +2,8 @@ import { HTMLAttributes } from "react";
 
 export function MarkdownUl({ children }: HTMLAttributes<HTMLUListElement>) {
   return (
-    <ul className="my-4 ml-6 flex list-disc flex-col gap-2">{children}</ul>
+    <ul className="ml-8 mt-5 flex list-disc flex-col gap-2 [li>&]:mt-2.5">
+      {children}
+    </ul>
   );
 }

--- a/frontend/src/routes/Provider/components/VersionInfo.tsx
+++ b/frontend/src/routes/Provider/components/VersionInfo.tsx
@@ -50,7 +50,7 @@ export function ProviderVersionInfo() {
   };
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-5">
       <div className="flex items-center justify-between">
         <VersionInfo
           currentVersion={version}
@@ -62,11 +62,7 @@ export function ProviderVersionInfo() {
           onChange={handleLanguageChange}
         />
       </div>
-      {version !== data.versions[0].id && (
-        <div className="mb-4">
-          <OldVersionBanner />
-        </div>
-      )}
+      {version !== data.versions[0].id && <OldVersionBanner />}
     </div>
   );
 }


### PR DESCRIPTION
Changelog:
- changed scroll margins on headings to match the horizontal padding of the container
- added top margin to the `<H1>` component that's reset to 0 if a heading is the first child in the container to avoid doubled space above it
- added margin resetting for `<H2>` and `<H3>`
- tweaked space between list elements to be half of the space between regular elements
- added small left padding to list elements to slightly separate bullets/numbers from the content
- increased line height in lists and paragraphs
- removed bottom margins from `<Ol>` and `<Ul>` lists, and made sure they have uniform top margins
- decreased top margins from lists inside list elements to match spacing between regular list items
- added top margin reset to any paragraph in a list element when it's the first element inside (to avoid doubled spacing)
- removed margin from the version info banner which was unnecessary