### PR TITLE
Display more versions before the active one near the end of the list

### DIFF
--- a/frontend/src/components/VersionsSidebarBlock/index.tsx
+++ b/frontend/src/components/VersionsSidebarBlock/index.tsx
@@ -102,7 +102,11 @@ function VersionTreeViewNestedItems({
   const visibleCount = expanded ? children.length : 5;
 
   const visibleChildren = useMemo(() => {
-    const start = Math.max(0, activeIndex - Math.floor(visibleCount / 2));
+    const start = Math.max(
+      0,
+      Math.min(activeIndex - 2, children.length - visibleCount),
+    );
+
     const end = Math.min(start + visibleCount, children.length);
     return children.slice(start, end);
   }, [activeIndex, children, visibleCount]);


### PR DESCRIPTION
If you pick a version near or at the end of a version section you'll notice that there's only 3-4 versions total instead of the constant 5 (when possible). This PR adjusts the logic to show more versions before the active one whenever possible.

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/cc119e86-854b-4bac-b5e0-c9a0d41435d9">|<video src="https://github.com/user-attachments/assets/a70c45ca-c302-4ef8-9618-6fe52574c1d4">|

