### PR TITLE
Handle custom admonition syntax

### DIFF
--- a/frontend/src/components/Markdown/P.tsx
+++ b/frontend/src/components/Markdown/P.tsx
@@ -26,9 +26,13 @@ function getAdmonitionMatch(children: ReactNode) {
     content = children[0];
   }
 
+  if (!content) {
+    return null;
+  }
+
   const match = content.match(admonitionRegex);
 
-  if (!match || !match.groups) {
+  if (!match?.groups?.prefix || !match?.groups?.content) {
     return null;
   }
 

--- a/frontend/src/components/Markdown/P.tsx
+++ b/frontend/src/components/Markdown/P.tsx
@@ -2,7 +2,9 @@ import { HTMLAttributes, ReactNode } from "react";
 import { Paragraph } from "../Paragraph";
 import clsx from "clsx";
 
-const admonitionRegex = /^(?<prefix>!>|~>|->)\s+(?<content>.*)$/;
+const WARNING_MARK = "~>";
+const DANGER_MARK = "!>";
+const NOTE_MARK = "->";
 
 function getAdmonitionClassName(prefix: string) {
   switch (prefix) {
@@ -30,16 +32,18 @@ function getAdmonitionMatch(children: ReactNode) {
     return null;
   }
 
-  const match = content.match(admonitionRegex);
-
-  if (!match?.groups?.prefix || !match?.groups?.content) {
-    return null;
+  if (
+    content.startsWith(WARNING_MARK) ||
+    content.startsWith(DANGER_MARK) ||
+    content.startsWith(NOTE_MARK)
+  ) {
+    return {
+      prefix: content.slice(0, 2),
+      content: content.slice(2).trim(),
+    };
   }
 
-  return {
-    prefix: match.groups.prefix,
-    content: match.groups.content,
-  };
+  return null;
 }
 
 export function MarkdownP({ children }: HTMLAttributes<HTMLParagraphElement>) {

--- a/frontend/src/components/Markdown/P.tsx
+++ b/frontend/src/components/Markdown/P.tsx
@@ -1,7 +1,55 @@
-import { HTMLAttributes } from "react";
+import { HTMLAttributes, ReactNode } from "react";
 import { Paragraph } from "../Paragraph";
+import clsx from "clsx";
+
+const admonitionRegex = /^(?<prefix>!>|~>|->)\s+(?<text>.*)$/;
+
+const getAdmonitionClassName = (prefix: string) => {
+  switch (prefix) {
+    case "->":
+      return "bg-sky-100 text-sky-800 dark:bg-sky-950 dark:text-sky-100";
+    case "!>":
+      return "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-100";
+    case "~>":
+      return "bg-yellow-100 text-yellow-800 dark:bg-yellow-950 dark:text-yellow-100";
+    default:
+      return "";
+  }
+};
+
+function getFirstLine(children: ReactNode) {
+  if (typeof children === "string") {
+    return children;
+  }
+
+  return Array.isArray(children) && typeof children[0] === "string"
+    ? children[0]
+    : null;
+}
 
 export function MarkdownP({ children }: HTMLAttributes<HTMLParagraphElement>) {
+  const firstLine = getFirstLine(children);
+
+  if (firstLine && admonitionRegex.test(firstLine)) {
+    const match = firstLine.match(admonitionRegex);
+
+    if (match?.groups) {
+      const { prefix, text } = match.groups;
+      const className = getAdmonitionClassName(prefix);
+      const remainingLines = Array.isArray(children) ? children.slice(1) : null;
+
+      return (
+        <div
+          role="alert"
+          className={clsx("mt-5 px-3 py-2 [li>&:first-child]:mt-0", className)}
+        >
+          {text}
+          {remainingLines}
+        </div>
+      );
+    }
+  }
+
   return (
     <Paragraph className="mt-5 leading-7 [li>&:first-child]:mt-0">
       {children}

--- a/frontend/src/components/Markdown/P.tsx
+++ b/frontend/src/components/Markdown/P.tsx
@@ -8,11 +8,11 @@ const NOTE_MARK = "->";
 
 function getAdmonitionClassName(prefix: string) {
   switch (prefix) {
-    case "->":
+    case NOTE_MARK:
       return "bg-sky-100 text-sky-800 dark:bg-sky-950 dark:text-sky-100";
-    case "!>":
+    case DANGER_MARK:
       return "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-100";
-    case "~>":
+    case WARNING_MARK:
       return "bg-yellow-100 text-yellow-800 dark:bg-yellow-950 dark:text-yellow-100";
     default:
       return "";


### PR DESCRIPTION
This adds support for the custom admonition syntax that providers and modules may use in their docs to render special blocks with warnings/notes/etc. We could probably convert this into a remark/rehype plugin but this approach was quicker to implement.

We could also add support for the syntax that GH supports so that maintainers of providers and modules could render these blocks on both GH and our Registry UI in a unified way.

Closes #80 