### PR TITLE
Disallow changing right padding

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" class="scroll-smooth [scrollbar-gutter:stable]">
+<html lang="en" class="scroll-smooth !pr-0 [scrollbar-gutter:stable]">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
When you open the search bar the library we use (Headless UI) [sets right padding](https://github.com/tailwindlabs/headlessui/blob/2ff8458b0043f900bf6f8267f01385a6f7df2f04/packages/%40headlessui-react/src/hooks/document-overflow/adjust-scrollbar-padding.ts#L25) to offset the lack of scrollbar. Since we enforce stable scrollbar gutters we don't need the padding, otherwise we get doubled space.

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/f4b1b146-d2ad-4998-abc1-3f680aa670be">|<video src="https://github.com/user-attachments/assets/4ca79626-b904-4b68-b526-8d7a3f6bb629">|


