### PR TITLE
Add padding between search dropdown and viewport

### DIFF
--- a/frontend/src/components/Search/index.tsx
+++ b/frontend/src/components/Search/index.tsx
@@ -232,7 +232,7 @@ export function Search({
 
         <ComboboxOptions
           anchor="bottom start"
-          className="z-10 max-h-96 w-[var(--input-width)] divide-y divide-gray-300 bg-gray-200 [--anchor-max-height:theme(height.96)] empty:hidden dark:divide-gray-900 dark:bg-gray-800"
+          className="z-10 max-h-96 w-[var(--input-width)] divide-y divide-gray-300 bg-gray-200 [--anchor-max-height:theme(height.96)] [--anchor-padding:theme(padding.4)] empty:hidden dark:divide-gray-900 dark:bg-gray-800"
         >
           {filtered.map((item) => (
             <div key={item.type}>


### PR DESCRIPTION
If the search dropdown renders below the search input it might look like it's cut. This PR adds a bit of padding between the dropdown and viewport to make clear that it has a correct height.

![Screenshot 2024-09-03 at 16 17 29](https://github.com/user-attachments/assets/a2f2deab-b890-4939-8bbf-07852fe9e99c)
