### PR TITLE
Clamp description of search results in the dropdown

### DIFF
--- a/frontend/src/components/Search/ModuleResult.tsx
+++ b/frontend/src/components/Search/ModuleResult.tsx
@@ -8,7 +8,9 @@ export function SearchModuleResult({ result }: SearchModuleResultProps) {
   return (
     <>
       <div className="text-sm">{result.displayTitle}</div>
-      <div className="text-xs text-gray-500">{result.description}</div>
+      <div className="line-clamp-3 text-xs text-gray-500">
+        {result.description}
+      </div>
     </>
   );
 }

--- a/frontend/src/components/Search/OtherResult.tsx
+++ b/frontend/src/components/Search/OtherResult.tsx
@@ -8,7 +8,9 @@ export function SearchOtherResult({ result }: SearchOtherResultProps) {
   return (
     <>
       <div className="text-sm">{result.addr}</div>
-      <div className="text-xs text-gray-500">{result.description}</div>
+      <div className="line-clamp-3 text-xs text-gray-500">
+        {result.description}
+      </div>
     </>
   );
 }

--- a/frontend/src/components/Search/ProviderResult.tsx
+++ b/frontend/src/components/Search/ProviderResult.tsx
@@ -5,25 +5,31 @@ interface SearchProviderResultProps {
 }
 
 export function SearchProviderResult({ result }: SearchProviderResultProps) {
+  const description = (
+    <div className="line-clamp-3 text-xs text-gray-500">
+      {result.description}
+    </div>
+  );
+
   if (result.type === SearchResultType.ProviderResource) {
     return (
       <>
         <div className="text-sm">Resource: {result.displayTitle}</div>
-        <div className="text-xs text-gray-500">{result.description}</div>
+        {description}
       </>
     );
   } else if (result.type === SearchResultType.ProviderDatasource) {
     return (
       <>
         <div className="text-sm">Data source: {result.displayTitle}</div>
-        <div className="text-xs text-gray-500">{result.description}</div>
+        {description}
       </>
     );
   } else if (result.type === SearchResultType.ProviderFunction) {
     return (
       <>
         <div className="text-sm">Function: {result.displayTitle}</div>
-        <div className="text-xs text-gray-500">{result.description}</div>
+        {description}
       </>
     );
   }
@@ -31,7 +37,7 @@ export function SearchProviderResult({ result }: SearchProviderResultProps) {
   return (
     <>
       <div className="text-sm">{result.addr}</div>
-      <div className="text-xs text-gray-500">{result.description}</div>
+      {description}
     </>
   );
 }


### PR DESCRIPTION
Some search results may have pretty long descriptions so to keep things in control let's clamp max lines to 3 which should be enough.