### PR TITLE
Keep previous search results while querying

### DIFF
--- a/frontend/src/q.ts
+++ b/frontend/src/q.ts
@@ -1,10 +1,15 @@
-import { queryOptions, skipToken } from "@tanstack/react-query";
+import {
+  keepPreviousData,
+  queryOptions,
+  skipToken,
+} from "@tanstack/react-query";
 import { api } from "@/query";
 import { definitions } from "./api";
 
 export const getSearchQuery = (query: string) =>
   queryOptions({
     queryKey: ["search", query],
+    placeholderData: keepPreviousData,
     queryFn:
       query.length > 0
         ? async ({ signal }) => {


### PR DESCRIPTION
By keeping previous results we avoid the blinking of the search dropdown which enables a bit smoother UX.