### PR TITLE
Adding a license confidence override threshold

### DIFF
--- a/backend/internal/license/license_detector.go
+++ b/backend/internal/license/license_detector.go
@@ -140,7 +140,7 @@ type Config struct {
 	CompatibleLicenses  []string
 	ConfidenceThreshold float32
 	// ConfidenceOverrideThreshold is the limit at which a detected license overrides all other detected licenses.
-	// Defaults to 98.
+	// Defaults to 98%.
 	ConfidenceOverrideThreshold float32
 }
 


### PR DESCRIPTION
This PR adds a confidence override threshold for license scanning. If this threshold is met, all other detected licenses are ignored.