### PR TITLE
Do not trim admonition content

### DIFF
--- a/frontend/src/components/Markdown/P.tsx
+++ b/frontend/src/components/Markdown/P.tsx
@@ -20,26 +20,28 @@ function getAdmonitionClassName(prefix: string) {
 }
 
 function getAdmonitionMatch(children: ReactNode) {
-  let content = "";
+  let text = "";
 
   if (typeof children === "string") {
-    content = children;
+    text = children;
   } else if (Array.isArray(children) && typeof children[0] === "string") {
-    content = children[0];
+    text = children[0];
   }
 
-  if (!content) {
+  if (!text) {
     return null;
   }
 
   if (
-    content.startsWith(WARNING_MARK) ||
-    content.startsWith(DANGER_MARK) ||
-    content.startsWith(NOTE_MARK)
+    text.startsWith(WARNING_MARK) ||
+    text.startsWith(DANGER_MARK) ||
+    text.startsWith(NOTE_MARK)
   ) {
+    const content = text.slice(2);
+
     return {
-      prefix: content.slice(0, 2),
-      content: content.slice(2).trim(),
+      prefix: text.slice(0, 2),
+      content: content.trim() ? content : null,
     };
   }
 


### PR DESCRIPTION
The custom admonition syntax doesn't require a title/type so in that case we might be trimming whitespace that separates the first child and any JSX element that follows it. I've adjusted the logic to remove whitespace only if there's nothing left afterwards.

Here's an example of such admonition:
https://search.opentofu.org/provider/hashicorp/akamai/latest

![Screenshot 2024-09-05 at 14 06 31](https://github.com/user-attachments/assets/6089ed3e-03de-4e47-a870-8acb7a2c0639)

And here's the preview of the fix:
https://do-not-trim-admonition-conte.registry-ui-dxi.pages.dev/provider/hashicorp/akamai/latest

![Screenshot 2024-09-05 at 14 07 11](https://github.com/user-attachments/assets/1096ea0a-a299-48c2-bc0c-cfd1a72f5555)


## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] My contribution is compatible with the MPL-2.0 license and I have provided a DCO sign-off on all my commits.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
