### PR TITLE
Reset the top margin of paragraphs and admonitions if they are first elements in markdown content

### DIFF
--- a/frontend/src/components/Markdown/P.tsx
+++ b/frontend/src/components/Markdown/P.tsx
@@ -57,7 +57,10 @@ export function MarkdownP({ children }: HTMLAttributes<HTMLParagraphElement>) {
     return (
       <div
         role="alert"
-        className={clsx("mt-5 px-3 py-2 [li>&:first-child]:mt-0", className)}
+        className={clsx(
+          "mt-5 px-3 py-2 first:mt-0 [li>&:first-child]:mt-0",
+          className,
+        )}
       >
         {content}
         {remainingContent}
@@ -66,7 +69,7 @@ export function MarkdownP({ children }: HTMLAttributes<HTMLParagraphElement>) {
   }
 
   return (
-    <Paragraph className="mt-5 leading-7 [li>&:first-child]:mt-0">
+    <Paragraph className="mt-5 leading-7 first:mt-0 [li>&:first-child]:mt-0">
       {children}
     </Paragraph>
   );


### PR DESCRIPTION
Before: https://search.opentofu.org/provider/hashicorp/akamai/latest
After: https://reset-paragraphs-top-margin.registry-ui-dxi.pages.dev/provider/hashicorp/akamai/latest

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] My contribution is compatible with the MPL-2.0 license and I have provided a DCO sign-off on all my commits.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
