### PR TITLE
Use groupBy util to support older browsers

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "@vitejs/plugin-react": "^4.3.1",
         "autoprefixer": "^10.4.20",
         "clsx": "^2.1.1",
+        "es-toolkit": "^1.17.0",
         "eslint": "^9.9.1",
         "eslint-plugin-react-hooks": "^5.1.0-rc.0",
         "eslint-plugin-react-refresh": "^0.4.11",
@@ -2841,6 +2842,16 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.17.0.tgz",
+      "integrity": "sha512-aJvpNxK7d+I+Rt9tmdwzelxTe4EwtxX1Kv0xv6ZTRWJBpMCxe0vxTLLW4STz6pHYjtyTTrEkonNXLaBsYHg2Yw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.21.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "@vitejs/plugin-react": "^4.3.1",
     "autoprefixer": "^10.4.20",
     "clsx": "^2.1.1",
+    "es-toolkit": "^1.17.0",
     "eslint": "^9.9.1",
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.11",

--- a/frontend/src/components/LicenseSidebarBlock/index.tsx
+++ b/frontend/src/components/LicenseSidebarBlock/index.tsx
@@ -3,6 +3,7 @@ import { Fragment, ReactNode } from "react";
 import { definitions } from "@/api";
 import { Icon } from "../Icon";
 import { info } from "@/icons/info";
+import { groupBy } from "es-toolkit";
 
 interface BlockProps {
   license?: definitions["LicenseList"];
@@ -33,10 +34,7 @@ export function LicenseSidebarBlock(props: BlockProps) {
       (a, b) => b.confidence - a.confidence,
     );
 
-    const groupedLicenses = Object.groupBy(
-      sortedLicenses,
-      (license) => license.link,
-    );
+    const groupedLicenses = groupBy(sortedLicenses, (license) => license.link);
 
     const licenses = Object.entries(groupedLicenses).map(([link, license]) => (
       <li className="flex flex-col items-start gap-2" key={link}>


### PR DESCRIPTION
The `groupBy` is still to new, so I've used `groupBy` from `es-toolkit` which is a smaller and faster alternative to `lodash`. 

This should fix #193

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] My contribution is compatible with the MPL-2.0 license and I have provided a DCO sign-off on all my commits.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
