### PR TITLE
Fix access to provider data in error boundary

### DIFF
--- a/frontend/src/routes/Provider/components/Error.tsx
+++ b/frontend/src/routes/Provider/components/Error.tsx
@@ -2,15 +2,23 @@ import { NotFoundPageError } from "@/utils/errors";
 import { Navigate, useLocation, useRouteError } from "react-router-dom";
 import { useProviderParams } from "../hooks/useProviderParams";
 
+function ProviderVersionRedirect() {
+  const params = useProviderParams();
+
+  return (
+    <Navigate
+      to={`/provider/${params.namespace}/${params.provider}/latest`}
+      replace
+    />
+  );
+}
+
 export function ProviderError() {
   const routeError = useRouteError() as Error;
   const location = useLocation();
-  const { namespace, provider, version } = useProviderParams();
 
   if (routeError instanceof NotFoundPageError && location.state?.fromVersion) {
-    return (
-      <Navigate to={`/provider/${namespace}/${provider}/${version}`} replace />
-    );
+    return <ProviderVersionRedirect />;
   }
 
   throw routeError;


### PR DESCRIPTION
Fixes #197

In cases where we don't have any provider version data we cannot use the data from the middleware. I've moved the logic into a component that'll run only when the data is available.

Preview:
https://521d63ef.registry-ui-dxi.pages.dev/provider/nonexistent/nonexistent/latest

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] My contribution is compatible with the MPL-2.0 license and I have provided a DCO sign-off on all my commits.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
