### PR TITLE
Add edit links to submodules and examples

### DIFF
--- a/frontend/src/routes/ModuleExample/Readme/index.tsx
+++ b/frontend/src/routes/ModuleExample/Readme/index.tsx
@@ -1,20 +1,34 @@
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useSuspenseQueries, useSuspenseQuery } from "@tanstack/react-query";
 
 import { Markdown } from "@/components/Markdown";
-import { getModuleExampleReadmeQuery } from "../query";
+import {
+  getModuleExampleDataQuery,
+  getModuleExampleReadmeQuery,
+} from "../query";
 import { useModuleExampleParams } from "../hooks/useModuleExampleParams";
 import { Suspense } from "react";
 import { ModuleExampleMetaTags } from "../components/MetaTags";
+import { EditLink } from "@/components/EditLink";
 
 function ModuleExampleReadmeContent() {
   const { namespace, name, target, version, example } =
     useModuleExampleParams();
 
-  const { data } = useSuspenseQuery(
-    getModuleExampleReadmeQuery(namespace, name, target, version, example),
-  );
+  const [{ data }, { data: exampleData }] = useSuspenseQueries({
+    queries: [
+      getModuleExampleReadmeQuery(namespace, name, target, version, example),
+      getModuleExampleDataQuery(namespace, name, target, version, example),
+    ],
+  });
 
-  return <Markdown text={data} />;
+  const editLink = exampleData.edit_link;
+
+  return (
+    <>
+      <Markdown text={data} />
+      {editLink && <EditLink url={editLink} />}
+    </>
+  );
 }
 
 function ModuleExampleReadmeContentSkeleton() {

--- a/frontend/src/routes/ModuleSubmodule/Readme/index.tsx
+++ b/frontend/src/routes/ModuleSubmodule/Readme/index.tsx
@@ -1,20 +1,40 @@
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useSuspenseQueries } from "@tanstack/react-query";
 
 import { Markdown } from "@/components/Markdown";
-import { getModuleSubmoduleReadmeQuery } from "../query";
+import {
+  getModuleSubmoduleDataQuery,
+  getModuleSubmoduleReadmeQuery,
+} from "../query";
 import { useModuleSubmoduleParams } from "../hooks/useModuleSubmoduleParams";
 import { Suspense } from "react";
 import { ModuleSubmoduleMetaTags } from "../components/MetaTags";
+import { EditLink } from "@/components/EditLink";
 
 function ModuleSubmoduleReadmeContent() {
   const { namespace, name, target, version, submodule } =
     useModuleSubmoduleParams();
 
-  const { data } = useSuspenseQuery(
-    getModuleSubmoduleReadmeQuery(namespace, name, target, version, submodule),
-  );
+  const [{ data }, { data: submoduleData }] = useSuspenseQueries({
+    queries: [
+      getModuleSubmoduleReadmeQuery(
+        namespace,
+        name,
+        target,
+        version,
+        submodule,
+      ),
+      getModuleSubmoduleDataQuery(namespace, name, target, version, submodule),
+    ],
+  });
 
-  return <Markdown text={data} />;
+  const editLink = submoduleData.edit_link;
+
+  return (
+    <>
+      <Markdown text={data} />
+      {editLink && <EditLink url={editLink} />}
+    </>
+  );
 }
 
 function ModuleSubmoduleReadmeContentSkeleton() {


### PR DESCRIPTION
We have them in main module's readme as well as in provider details, but not in submodules and examples.

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] My contribution is compatible with the MPL-2.0 license and I have provided a DCO sign-off on all my commits.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
