### PR TITLE
feat: add backend linting on github actions

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2,9 +2,6 @@ name: Verify
 permissions: {}
 on:
   pull_request:
-  push:
-    branches:
-    - feat/backend-lint
 
 jobs:
   generate:
@@ -48,10 +45,10 @@ jobs:
       - name: Run go generate
         working-directory: backend
         run: go generate ./...
-      # - name: Run tests
-      #   working-directory: backend
-      #   run: |
-      #     go test ./...
+      - name: Run tests
+        working-directory: backend
+        run: |
+          go test ./...
   frontend:
     name: Frontend Lint and Test
     runs-on: ubuntu-latest

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -90,4 +90,4 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.60
-           args: ./backend ./search 
+          args: ./backend ./search 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -90,4 +90,4 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.60
-           args: /backend
+           args: ./backend ./search 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -88,6 +88,6 @@ jobs:
           go-version-file: 'backend/go.mod'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
-        working-directory: backend
         with:
           version: v1.60
+           args: /backend

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2,7 +2,8 @@ name: Verify
 permissions: {}
 on:
   pull_request:
-  branches:
+  push:
+    branches:
     - feat/backend-lint
 
 jobs:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -83,7 +83,7 @@ jobs:
       matrix:
         modules:
           - backend
-          - search 
+          - search/pg-indexer
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2,6 +2,8 @@ name: Verify
 permissions: {}
 on:
   pull_request:
+  branches:
+    - feat/backend-lint
 
 jobs:
   generate:
@@ -14,10 +16,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: 'backend/go.mod'
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
-        with:
-          version: v1.60.0
       - name: Cache tofu binary
         uses: actions/cache@v4
         with:
@@ -77,3 +75,18 @@ jobs:
         working-directory: frontend
         run:
           npm run test
+  backend-lint:
+    name: Backend Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'backend/go.mod'
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        working-directory: backend
+        with:
+          version: v1.60

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -90,4 +90,4 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.60
-          args: ./backend ./search 
+          args: ./... ./backend ./search 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -48,10 +48,10 @@ jobs:
       - name: Run go generate
         working-directory: backend
         run: go generate ./...
-      - name: Run tests
-        working-directory: backend
-        run: |
-          go test ./...
+      # - name: Run tests
+      #   working-directory: backend
+      #   run: |
+      #     go test ./...
   frontend:
     name: Frontend Lint and Test
     runs-on: ubuntu-latest
@@ -79,6 +79,11 @@ jobs:
   backend-lint:
     name: Backend Lint
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        modules:
+          - backend
+          - search 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -86,8 +91,8 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: 'backend/go.mod'
-      - name: golangci-lint
+      - name: Backend Linting
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.60
-          args: ./... ./backend ./search 
+          version: v1.62
+          working-directory: ${{ matrix.modules }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -14,6 +14,10 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: 'backend/go.mod'
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.60.0
       - name: Cache tofu binary
         uses: actions/cache@v4
         with:

--- a/backend/internal/backend.go
+++ b/backend/internal/backend.go
@@ -177,7 +177,7 @@ func (f ForceRegenerateEntry) MustRegenerateProvider(_ context.Context, addr pro
 	})
 }
 
-func (g GenerateConfig) validate() error {
+func (g GenerateConfig) validate() error { //nolint:unused
 	if g.Name != "" && g.Namespace == "" {
 		return fmt.Errorf("cannot use name filtering without namespace filtering")
 	}

--- a/backend/internal/blocklist/blocklist.go
+++ b/backend/internal/blocklist/blocklist.go
@@ -65,6 +65,7 @@ func (b *blockListType[T]) UnmarshalJSON(data []byte) error {
 func (b *blockList) LoadFile(file string) error {
 	blockListContents, err := os.ReadFile(file)
 	if err != nil {
+		return err
 	}
 
 	if err := json.Unmarshal(blockListContents, &b); err != nil {

--- a/backend/internal/indexstorage/bufferedstorage/index.go
+++ b/backend/internal/indexstorage/bufferedstorage/index.go
@@ -202,7 +202,7 @@ func (l *localIndex) Close() error {
 }
 
 func (l *localIndex) trySave(ctx context.Context) error {
-	if time.Now().Sub(l.lastCommitted) < 30*time.Second {
+	if time.Since(l.lastCommitted) < 30*time.Second {
 		return nil
 	}
 

--- a/backend/internal/providerindex/generator.go
+++ b/backend/internal/providerindex/generator.go
@@ -128,6 +128,9 @@ func (d *documentationGenerator) Generate(ctx context.Context, opts ...Opts) err
 func (d *documentationGenerator) GenerateNamespace(ctx context.Context, namespace string, opts ...Opts) error {
 	d.log.Info(ctx, "Listing all providers in namespace %s...", namespace)
 	providerList, err := d.metadataAPI.ListProvidersByNamespace(ctx, namespace, true)
+	if err != nil {
+		return err
+	}
 
 	d.log.Info(ctx, "Loaded %d providers", len(providerList))
 

--- a/backend/internal/providerindex/providerdocsource/scrape_test.go
+++ b/backend/internal/providerindex/providerdocsource/scrape_test.go
@@ -148,7 +148,9 @@ Manages projects.
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			doc := &docItem{}
-			s.ExtractFrontmatterPermissively(context.Background(), []byte(tt.input), doc) //nolint:all
+			if err := s.ExtractFrontmatterPermissively(context.Background(), []byte(tt.input), doc); err != nil {
+				t.Errorf("Failed to extract frontmatter: (%v)", err)
+			}
 
 			if doc.Name != tt.expected.Name {
 				t.Errorf("expected %q, got %q", tt.expected.Name, doc.Name)

--- a/backend/internal/providerindex/providerdocsource/scrape_test.go
+++ b/backend/internal/providerindex/providerdocsource/scrape_test.go
@@ -148,7 +148,7 @@ Manages projects.
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			doc := &docItem{}
-			s.ExtractFrontmatterPermissively(context.Background(), []byte(tt.input), doc)
+			s.ExtractFrontmatterPermissively(context.Background(), []byte(tt.input), doc) //nolint:all
 
 			if doc.Name != tt.expected.Name {
 				t.Errorf("expected %q, got %q", tt.expected.Name, doc.Name)

--- a/backend/internal/providerindex/search.go
+++ b/backend/internal/providerindex/search.go
@@ -105,6 +105,6 @@ func (p providerSearch) removeProviderVersionFromSearchIndex(ctx context.Context
 	return nil
 }
 
-func (p providerSearch) removeModuleFromSearchIndex(ctx context.Context, addr module.Addr) error {
+func (p providerSearch) removeModuleFromSearchIndex(ctx context.Context, addr module.Addr) error { //nolint:unused
 	return p.searchAPI.RemoveItem(ctx, searchtypes.IndexID(indexPrefix+"/"+addr.String()))
 }

--- a/backend/internal/providerindex/search.go
+++ b/backend/internal/providerindex/search.go
@@ -11,8 +11,6 @@ import (
 	"github.com/opentofu/registry-ui/internal/search/searchtypes"
 )
 
-const indexPrefix = "providers"
-
 type providerSearch struct {
 	searchAPI search.API
 }
@@ -92,7 +90,7 @@ func (p providerSearch) indexProviderVersion(ctx context.Context, providerAddr p
 	return nil
 }
 
-func (p providerSearch) removeProviderVersionFromSearchIndex(ctx context.Context, addr provider.Addr, version provider.VersionNumber) error {
+func (p providerSearch) removeProviderVersionFromSearchIndex(ctx context.Context, addr provider.Addr, version provider.VersionNumber) error { //nolint:unused
 	for _, t := range []searchtypes.IndexType{
 		searchtypes.IndexTypeProvider,
 		searchtypes.IndexTypeProviderResource,
@@ -106,5 +104,5 @@ func (p providerSearch) removeProviderVersionFromSearchIndex(ctx context.Context
 }
 
 func (p providerSearch) removeModuleFromSearchIndex(ctx context.Context, addr module.Addr) error { //nolint:unused
-	return p.searchAPI.RemoveItem(ctx, searchtypes.IndexID(indexPrefix+"/"+addr.String()))
+	return p.searchAPI.RemoveItem(ctx, searchtypes.IndexID("providers/"+addr.String()))
 }

--- a/backend/internal/providerindex/search.go
+++ b/backend/internal/providerindex/search.go
@@ -11,6 +11,8 @@ import (
 	"github.com/opentofu/registry-ui/internal/search/searchtypes"
 )
 
+const indexPrefix = "providers"
+
 type providerSearch struct {
 	searchAPI search.API
 }
@@ -23,7 +25,7 @@ func (p providerSearch) indexProviderVersion(ctx context.Context, providerAddr p
 		popularity = providerDetails.UpstreamPopularity
 	}
 	providerItem := searchtypes.IndexItem{
-		ID:          searchtypes.IndexID("providers/" + providerAddr.String()),
+		ID:          searchtypes.IndexID(indexPrefix + "/" + providerAddr.String()),
 		Type:        searchtypes.IndexTypeProvider,
 		Addr:        providerAddr.String(),
 		Version:     string(version),
@@ -67,7 +69,7 @@ func (p providerSearch) indexProviderVersion(ctx context.Context, providerAddr p
 		for _, docItem := range item.items {
 			title := docItem.Title
 			if err := p.searchAPI.AddItem(ctx, searchtypes.IndexItem{
-				ID:          searchtypes.IndexID("providers/" + providerAddr.String() + "/" + item.typeName + "s/" + string(docItem.Name)),
+				ID:          searchtypes.IndexID(indexPrefix + "/" + providerAddr.String() + "/" + item.typeName + "s/" + string(docItem.Name)),
 				Type:        item.indexType,
 				Addr:        providerAddr.String(),
 				Version:     string(version),
@@ -104,5 +106,5 @@ func (p providerSearch) removeProviderVersionFromSearchIndex(ctx context.Context
 }
 
 func (p providerSearch) removeModuleFromSearchIndex(ctx context.Context, addr module.Addr) error { //nolint:unused
-	return p.searchAPI.RemoveItem(ctx, searchtypes.IndexID("providers/"+addr.String()))
+	return p.searchAPI.RemoveItem(ctx, searchtypes.IndexID(indexPrefix+"/"+addr.String()))
 }

--- a/backend/internal/registrycloner/git.go
+++ b/backend/internal/registrycloner/git.go
@@ -30,7 +30,7 @@ func (c cloner) cloneGitRepo(ctx context.Context) error {
 }
 
 // FetchTags fetches the tags for the repository in the specified directory.
-func (c cloner) fetchTags(ctx context.Context) error {
+func (c cloner) fetchTags(ctx context.Context) error { //nolint:unused
 	return c.runGitCommand(ctx, []string{"git", "fetch", "--tags", "--force"}, c.cfg.Directory)
 }
 


### PR DESCRIPTION
Closes #93

Adding golang linting for search/pg-indexer and backend folders:

After first run:

<img width="1473" alt="Screenshot 2025-01-03 at 09 56 32" src="https://github.com/user-attachments/assets/fa75afbc-0e6c-445d-86ac-ce02249cf805" />

How it looks on the pipeline:

<img width="392" alt="Screenshot 2025-01-04 at 00 58 10" src="https://github.com/user-attachments/assets/6ba73068-f390-4c05-bace-18d25a2bc674" />

Fixes:

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] My contribution is compatible with the MPL-2.0 license and I have provided a DCO sign-off on all my commits.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
