### PR TITLE
fix: remove word duplicate from instruction sidebar

### DIFF
--- a/frontend/src/routes/Provider/components/InstructionSidebarBlock.tsx
+++ b/frontend/src/routes/Provider/components/InstructionSidebarBlock.tsx
@@ -10,7 +10,7 @@ function Block({ children }: { children: ReactNode }) {
   return (
     <SidebarBlock title="How to use this provider">
       <Paragraph className="my-4">
-        Copy this code into your OpenTofu configuration and run run{" "}
+        Copy this code into your OpenTofu configuration and run{" "}
         <code className="text-sm text-purple-700 dark:text-purple-300">
           tofu init
         </code>{" "}


### PR DESCRIPTION
This pull request corrects the instruction sidebar localization by removing the duplicated word "run".

## Checklist

- [X] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [X] I have not used an AI coding assistant to create this PR.
- [X] My contribution is compatible with the MPL-2.0 license and I have provided a DCO sign-off on all my commits.
- [X] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.