### PR TITLE
Enable observability

### DIFF
--- a/search/worker/wrangler.toml
+++ b/search/worker/wrangler.toml
@@ -9,5 +9,9 @@ binding = "BUCKET"
 bucket_name = "registry-ui-api"
 preview_bucket_name = "registry-ui-api"
 
+[observability]
+enabled = true
+head_sampling_rate = 0.1
+
 [dev]
 ip = "0.0.0.0"

--- a/search/worker/wrangler.toml
+++ b/search/worker/wrangler.toml
@@ -11,7 +11,7 @@ preview_bucket_name = "registry-ui-api"
 
 [observability]
 enabled = true
-head_sampling_rate = 0.1
+head_sampling_rate = 0.1  # 10% of requests are logged
 
 [dev]
 ip = "0.0.0.0"


### PR DESCRIPTION
Enabling 10% of requests to the search worker. James enabled this yesterday and this graph shows the volume of logging. I've changed to log only 10% of the requests to decrease the costs and by reading the logs, I think this will be enough.

<img width="1271" alt="Screenshot 2025-02-26 at 16 14 28" src="https://github.com/user-attachments/assets/b90acbec-0b5d-4fa1-bc25-2550beb5df08" />


## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] My contribution is compatible with the MPL-2.0 license and I have provided a DCO sign-off on all my commits.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
