### PR TITLE
fix: github actions are not using dependencies cache

### DIFF
--- a/.github/workflows/index-manual.yml
+++ b/.github/workflows/index-manual.yml
@@ -39,8 +39,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup go
         uses: actions/setup-go@v5
-        with:
-          go-version-file: 'backend/go.mod'
+        working-directory: backend
       - name: Cache tofu binary
         uses: actions/cache@v4
         with:

--- a/.github/workflows/index.yml
+++ b/.github/workflows/index.yml
@@ -18,8 +18,7 @@ jobs:
           ref: main
       - name: Setup go
         uses: actions/setup-go@v5
-        with:
-          go-version-file: 'backend/go.mod'
+        working-directory: backend
       - name: Cache tofu binary
         uses: actions/cache@v4
         with:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -12,8 +12,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup go
         uses: actions/setup-go@v5
-        with:
-          go-version-file: 'backend/go.mod'
+        working-directory: backend
       - name: Cache tofu binary
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
Setup Go step on "Index (cron)" is not using the cache for the dependencies.

<img width="1148" alt="Screenshot 2025-03-03 at 10 45 51" src="https://github.com/user-attachments/assets/637679a6-24f2-44d7-9dae-794849e2f477" />

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] My contribution is compatible with the MPL-2.0 license and I have provided a DCO sign-off on all my commits.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
