### PR TITLE
fix: tofu binary cache doesn't work with working-directory

### DIFF
--- a/.github/workflows/index-manual.yml
+++ b/.github/workflows/index-manual.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Cache tofu binary
         uses: actions/cache@v4
         with:
-          path: ./internal/moduleindex/moduleschema/testtofu
+          path: ./backend/internal/moduleindex/moduleschema/testtofu
           key: tofu-binary
       - name: Build tofu
         run:

--- a/.github/workflows/index.yml
+++ b/.github/workflows/index.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Cache tofu binary
         uses: actions/cache@v4
         with:
-          path: ./internal/moduleindex/moduleschema/testtofu
+          path: ./backend/internal/moduleindex/moduleschema/testtofu
           key: tofu-binary
       - name: Build tofu
         run:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Cache tofu binary
         uses: actions/cache@v4
         with:
-          path: ./internal/moduleindex/moduleschema/testtofu
+          path: ./backend/internal/moduleindex/moduleschema/testtofu
           key: tofu-binary
       - name: Run go generate
         run: go generate ./...

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Cache tofu binary
         uses: actions/cache@v4
         with:
-          path: ./internal/moduleindex/moduleschema/testtofu
+          path: ./backend/internal/moduleindex/moduleschema/testtofu
           key: tofu-binary
       - name: Run go generate
         run: go generate ./...


### PR DESCRIPTION
setup-action/cache doesn't working with working-directory as well. Reverting it back to full path to the binary.

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] My contribution is compatible with the MPL-2.0 license and I have provided a DCO sign-off on all my commits.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
