### PR TITLE
Filter out providers that don't have valid versions

### DIFF
--- a/backend/internal/providerindex/generator.go
+++ b/backend/internal/providerindex/generator.go
@@ -237,6 +237,16 @@ func (d *documentationGenerator) scrape(ctx context.Context, providers []provide
 					return err
 				}
 
+				// Some providers may have versions detected by the registry, but somehow not in libregistry+scrape
+				// Filter them out here for now
+				if len(providerEntry.Versions) == 0 {
+					d.log.Info(ctx, "Provider %s does not have any versions, removing from UI... (%v)", addr, err)
+					lock.Lock()
+					providersToRemove = append(providersToRemove, addr)
+					lock.Unlock()
+					return nil
+				}
+
 				// Here we compare the provider entry to its original copy to make sure
 				// we are only writing this index if needed. This is needed because writes
 				// on R2 cost money, whereas reads don't and updating all the provider and


### PR DESCRIPTION
Fixes https://github.com/opentofu/registry-ui/issues/202

It's likely that having two codebases dealing with "what's a valid provider version" is a bad idea...

Example:
```
2025-03-03T10:42:01.6541185Z time=2025-03-03T10:41:59.212Z level=DEBUG-4 msg="Generating index for provider zhaochunqi/tencentcloud"
2025-03-03T10:42:01.7077130Z time=2025-03-03T10:41:59.237Z level=WARN msg="Invalid version number for provider zhaochunqi/tencentcloud: 1.61.8-alpha, skipping... (Invalid version: 1.61.8-alpha)" 
2025-03-03T10:42:01.7079092Z time=2025-03-03T10:41:59.237Z level=WARN msg="Invalid version number for provider zhaochunqi/tencentcloud: 1.61.10-alpha, skipping... (Invalid version: 1.61.10-alpha)"
2025-03-03T10:42:01.7080939Z time=2025-03-03T10:41:59.237Z level=WARN msg="Invalid version number for provider zhaochunqi/tencentcloud: 1.61.10-beta, skipping... (Invalid version: 1.61.10-beta)"
```


## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] My contribution is compatible with the MPL-2.0 license and I have provided a DCO sign-off on all my commits.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
