### PR TITLE
added /top/providers query to allow you to query up tothe top 500 providers

### DIFF
--- a/search/worker/src/index.ts
+++ b/search/worker/src/index.ts
@@ -1,14 +1,32 @@
 import { Client, neon, neonConfig } from '@neondatabase/serverless';
 
-import { DBClient } from "./types";
+import { DBClient } from './types';
 import { getClient } from './client';
-import { query } from './query';
-import { validateSearchRequest } from './validation';
+import { getTopProviders, query } from './query';
+import { validateSearchRequest, validateTopProvidersRequest } from './validation';
 
 async function fetchData(client: DBClient, queryParam: string, ctx: ExecutionContext): Promise<Response> {
 	try {
 		const start = performance.now();
 		const results = await query(client, queryParam);
+		const end = performance.now();
+		console.log(`Query took ${end - start}ms`);
+		ctx.waitUntil(client.end()); // Don't block on closing the connection
+		return Response.json(results, {
+			headers: {
+				'Cache-Control': 'public, max-age=300', // Cache for 5 mins
+			},
+		});
+	} catch (error) {
+		console.error('Error during fetch:', error);
+		return new Response('An internal server error occurred', { status: 500 });
+	}
+}
+
+async function fetchTopProviders(client: DBClient, limit: number, ctx: ExecutionContext): Promise<Response> {
+	try {
+		const start = performance.now();
+		const results = await getTopProviders(client, limit);
 		const end = performance.now();
 		console.log(`Query took ${end - start}ms`);
 		ctx.waitUntil(client.end()); // Don't block on closing the connection
@@ -32,6 +50,17 @@ async function handleSearchRequest(request: Request, env: Env, ctx: ExecutionCon
 	const client = await getClient(env.ENVIRONMENT, env.DATABASE_URL);
 	console.log('Querying for:', validation.queryParam);
 	const response = await fetchData(client, validation.queryParam, ctx);
+	return response;
+}
+
+async function handleTopProvidersRequest(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+	const validation = validateTopProvidersRequest(request);
+	if (validation.error) {
+		return new Response(validation.error.message, { status: validation.error.status });
+	}
+	const client = await getClient(env.ENVIRONMENT, env.DATABASE_URL);
+	console.log('Querying for top providers with limit:', validation.queryParam);
+	const response = await fetchTopProviders(client, validation.queryParam, ctx);
 	return response;
 }
 
@@ -84,6 +113,9 @@ export default {
 		}
 
 		switch (url.pathname) {
+			case '/providers/top':
+				response = await handleTopProvidersRequest(request, env, ctx);
+				break;
 			case '/registry/docs/search':
 			case '/search':
 				response = await handleSearchRequest(request, env, ctx);

--- a/search/worker/src/index.ts
+++ b/search/worker/src/index.ts
@@ -113,7 +113,7 @@ export default {
 		}
 
 		switch (url.pathname) {
-			case '/providers/top':
+			case '/top/providers':
 				response = await handleTopProvidersRequest(request, env, ctx);
 				break;
 			case '/registry/docs/search':

--- a/search/worker/src/query.ts
+++ b/search/worker/src/query.ts
@@ -5,41 +5,80 @@ export const query = async (client: DBClient, queryParam: string): Promise<Entit
 	return rows;
 };
 
+export const getTopProviders = async (client: DBClient, limit: number): Promise<Entity[]> => {
+	const { rows } = await client.query(topProvidersQuery, [limit]);
+	return rows;
+};
+
+// topProvidersQuery is used to get the top providers from the database.
+// It uses the popularity column to sort the providers and the title column to remove duplicates.
+// If we find a fork of a provider, we want to prioritize the `hashicorp` namespaced ones.
+// This is a quick hack to make sure we don't show the same provider multiple times.
+// We can improve this in the future by using a more sophisticated system to find duplicates.
+const topProvidersQuery = `SELECT DISTINCT ON (popularity, lower(title))
+addr, version, popularity
+FROM entities
+WHERE type = 'provider'
+ORDER BY popularity DESC, lower(title), 
+    CASE 
+        WHEN addr LIKE 'hashicorp/%' THEN 0 
+        ELSE 1 
+    END
+LIMIT $1`;
+
 const searchQuery = `
-	WITH search_terms AS (SELECT unnest(regexp_split_to_array($1, '[ /]+')) AS term),
-		 term_matches AS (SELECT e.*
-						  FROM entities e
-								   INNER JOIN search_terms st
-											  ON e.addr ILIKE '%' || st.term || '%'
-												  OR e.description ILIKE '%' || st.term || '%'
-						  GROUP BY id, last_updated, type, addr, version, title, description, link_variables, document, popularity, warnings),
-	     max_popularity AS (SELECT max(popularity) AS max_popularity FROM term_matches tm),
-		 ranked_entities AS (SELECT *,
-								 /* The rank fudge ranks providers and modules higher than their resources/submodules (excluding archived terraform-providers) */
-									CASE WHEN (type = 'provider' OR type = 'module') AND addr NOT LIKE 'terraform-providers/%' AND addr NOT LIKE 'opentofu/%' THEN 1 ELSE 0 END          AS type_rank_fudge,
-								 /* When warnings are present, rank the provider lower because it's likely deprecated. */
-								 /* DISABLED CASE WHEN warnings > 1 THEN -1 ELSE 0 END              AS warnings_rank_fudge, */
-								 0 as warnings_rank_fudge,
-								 /* Give a slight boost to providers with a higher star rating. */
-									tm.popularity / (SELECT CASE WHEN max_popularity > 0 THEN max_popularity ELSE 1 END FROM max_popularity) AS popularity_rank,
-								 /* Text similarity rankings, each taking a value from 0 to 1. */
-									similarity(tm.addr, $1)                                AS title_sim,
-									similarity(tm.description, $1)                         AS description_sim,
-									similarity(link_variables ->> 'name', $1)              AS name_sim
-							 FROM term_matches tm),
-		 providers AS (SELECT *
-					   FROM ranked_entities
-					   WHERE type LIKE 'provider%'
-					   ORDER BY (type_rank_fudge + warnings_rank_fudge + 1) *(popularity_rank + title_sim + name_sim + description_sim/0.5) DESC
-					   LIMIT 5),
-		 modules AS (SELECT *
-					 FROM ranked_entities
-					 WHERE type LIKE 'module%'
-					 ORDER BY (type_rank_fudge + warnings_rank_fudge + 1) * (popularity_rank + title_sim + name_sim + description_sim/0.5) DESC
-					 LIMIT 5)
-	SELECT *
-	FROM providers
-	UNION ALL
-	SELECT *
-	FROM modules;
+  WITH search_terms AS (
+    SELECT unnest(regexp_split_to_array($1, '[ /]+')) AS term
+  ),
+  term_matches AS (
+    SELECT e.*
+    FROM entities e
+    INNER JOIN search_terms st
+      ON e.addr ILIKE '%' || st.term || '%'
+      OR e.description ILIKE '%' || st.term || '%'
+    GROUP BY id, last_updated, type, addr, version, title, description, link_variables, document, popularity, warnings
+  ),
+  max_popularity AS (
+    SELECT max(popularity) AS max_popularity
+    FROM term_matches tm
+  ),
+  ranked_entities AS (
+    SELECT *,
+      /* The rank fudge ranks providers and modules higher than their resources/submodules (excluding archived terraform-providers) */
+      CASE 
+        WHEN (type = 'provider' OR type = 'module') 
+          AND addr NOT LIKE 'terraform-providers/%' 
+          AND addr NOT LIKE 'opentofu/%' THEN 1 
+        ELSE 0 
+      END AS type_rank_fudge,
+      /* When warnings are present, rank the provider lower because it's likely deprecated. */
+      /* DISABLED CASE WHEN warnings > 1 THEN -1 ELSE 0 END AS warnings_rank_fudge, */
+      0 AS warnings_rank_fudge,
+      /* Give a slight boost to providers with a higher star rating. */
+      tm.popularity / (SELECT CASE WHEN max_popularity > 0 THEN max_popularity ELSE 1 END FROM max_popularity) AS popularity_rank,
+      /* Text similarity rankings, each taking a value from 0 to 1. */
+      similarity(tm.addr, $1) AS title_sim,
+      similarity(tm.description, $1) AS description_sim,
+      similarity(link_variables ->> 'name', $1) AS name_sim
+    FROM term_matches tm
+  ),
+  providers AS (
+    SELECT *
+    FROM ranked_entities
+    WHERE type LIKE 'provider%'
+    ORDER BY (type_rank_fudge + warnings_rank_fudge + 1) * (popularity_rank + title_sim + name_sim + description_sim / 0.5) DESC
+    LIMIT 5
+  ),
+  modules AS (
+    SELECT *
+    FROM ranked_entities
+    WHERE type LIKE 'module%'
+    ORDER BY (type_rank_fudge + warnings_rank_fudge + 1) * (popularity_rank + title_sim + name_sim + description_sim / 0.5) DESC
+    LIMIT 5
+  )
+  SELECT *
+  FROM providers
+  UNION ALL
+  SELECT *
+  FROM modules;
 `;

--- a/search/worker/src/validation.ts
+++ b/search/worker/src/validation.ts
@@ -11,7 +11,7 @@ interface ValidationError {
 	};
 }
 
-type ValidationResul<T> = ValidationSuccess<T> | ValidationError;
+type ValidationResult<T> = ValidationSuccess<T> | ValidationError;
 
 const newValidationErrorResult = (message: string, status: number): ValidationError => ({ error: { message, status } });
 

--- a/search/worker/src/validation.ts
+++ b/search/worker/src/validation.ts
@@ -1,5 +1,5 @@
-interface ValidationSuccess {
-	queryParam: string;
+interface ValidationSuccess<T> {
+	queryParam: T;
 	error?: never; // Ensures this type does not have an error
 }
 
@@ -11,11 +11,11 @@ interface ValidationError {
 	};
 }
 
-type ValidationResult = ValidationSuccess | ValidationError;
+type ValidationResul<T> = ValidationSuccess<T> | ValidationError;
 
 const newValidationErrorResult = (message: string, status: number): ValidationError => ({ error: { message, status } });
 
-export function validateSearchRequest(request: Request): ValidationResult {
+export function validateSearchRequest(request: Request): ValidationResult<string> {
 	const url = new URL(request.url);
 
 	if (request.method !== 'GET') {
@@ -28,4 +28,29 @@ export function validateSearchRequest(request: Request): ValidationResult {
 	}
 
 	return { queryParam };
+}
+
+export function validateTopProvidersRequest(request: Request): ValidationResult<number> {
+	const url = new URL(request.url);
+
+	if (request.method !== 'GET') {
+		return newValidationErrorResult('Method not allowed', 405);
+	}
+
+	const limitParam = url.searchParams.get('limit');
+	if (!limitParam) {
+		return newValidationErrorResult('Query parameter "limit" is required', 400);
+	}
+
+	const limit = parseInt(limitParam, 10);
+	if (isNaN(limit) || limit <= 0) {
+		return newValidationErrorResult('Query parameter "limit" must be a positive integer', 400);
+	}
+
+	// don't allow limit to be greater than 500
+	if (limit > 500) {
+		return newValidationErrorResult('Query parameter "limit" must be less than or equal to 500', 400);
+	}
+
+	return { queryParam: limit };
 }


### PR DESCRIPTION
This also reformats the search query whitespace, it was annoying me.

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] My contribution is compatible with the MPL-2.0 license and I have provided a DCO sign-off on all my commits.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
