### PR TITLE
Always show module optional input defaults

### DIFF
--- a/frontend/src/components/ModuleInput/index.tsx
+++ b/frontend/src/components/ModuleInput/index.tsx
@@ -14,6 +14,7 @@ export function ModuleInput({
   description,
   defaultValue,
 }: ModuleInputProps) {
+  const showDefaultValue = defaultValue !== undefined;
   return (
     <li>
       <h4 id={name} className="group scroll-mt-5">
@@ -24,7 +25,7 @@ export function ModuleInput({
         <HeadingLink id={name} label={`${name} input`} />
       </h4>
       <Paragraph className="mt-1">{description}</Paragraph>
-      {!!defaultValue && (
+      {showDefaultValue && (
         <Paragraph className="mt-2">
           Default value:{" "}
           <code className="text-mono break-words text-sm text-purple-700 dark:text-purple-300">


### PR DESCRIPTION
Previously we coerced the default value to a boolean to decide if we should show it. This resulted in false negatives for defaults of `null` and `""` (empty string).


## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] My contribution is compatible with the MPL-2.0 license and I have provided a DCO sign-off on all my commits.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
