### PR TITLE
Rework how links are rendered from markdown files

### DIFF
--- a/frontend/src/routes/Provider/components/DocsContent.tsx
+++ b/frontend/src/routes/Provider/components/DocsContent.tsx
@@ -8,6 +8,7 @@ import {
 import { useProviderParams } from "../hooks/useProviderParams";
 import { getProviderDoc } from "../utils/getProviderDoc";
 import { EditLink } from "@/components/EditLink";
+import { reworkRelativePaths } from "./docsProcessor";
 
 export function ProviderDocsContent() {
   const { namespace, provider, type, doc, version, lang } = useProviderParams();
@@ -41,9 +42,14 @@ export function ProviderDocsContent() {
     return <ProviderDocsContentSkeleton />;
   }
 
+  let finalDocs = docs;
+  if (namespace && provider && version) {
+    finalDocs = reworkRelativePaths(docs || "", namespace, provider, version);
+  }
+
   return (
     <>
-      <Markdown text={docs} />
+      <Markdown text={finalDocs} />
       {editLink && <EditLink url={editLink} />}
     </>
   );

--- a/frontend/src/routes/Provider/components/docsProcessor.test.ts
+++ b/frontend/src/routes/Provider/components/docsProcessor.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, test } from "vitest";
+import {
+  stripExtension,
+  shortToLongPath,
+  reworkRelativePaths,
+  prefixAnchors,
+} from "./docsProcessor";
+
+describe("stripExtension", () => {
+  test("should strip .md extension", () => {
+    expect(stripExtension("/docs/overview.md")).toBe("/docs/overview");
+  });
+
+  test("should strip .html extension", () => {
+    expect(stripExtension("/docs/overview.html")).toBe("/docs/overview");
+  });
+
+  test("should not affect paths without extensions", () => {
+    expect(stripExtension("/docs/overview")).toBe("/docs/overview");
+  });
+
+  test("should handle paths with anchor links", () => {
+    expect(stripExtension("/docs/overview.md#section")).toBe(
+      "/docs/overview#section",
+    );
+    expect(stripExtension("/docs/overview.html#section")).toBe(
+      "/docs/overview#section",
+    );
+  });
+});
+
+describe("prefixAnchors", () => {
+  test("should prefix anchors with 'user-content-'", () => {
+    expect(prefixAnchors("/docs/overview#section")).toBe(
+      "/docs/overview#user-content-section",
+    );
+  });
+  test("should not modify paths without anchors", () => {
+    expect(prefixAnchors("/docs/overview")).toBe("/docs/overview");
+  });
+});
+
+describe("shortToLongPath", () => {
+  test("should convert /r/ to /resources/", () => {
+    expect(shortToLongPath("/docs/r/resource_name")).toBe(
+      "/docs/resources/resource_name",
+    );
+  });
+
+  test("should convert /d/ to /datasources/", () => {
+    expect(shortToLongPath("/docs/d/data_source_name")).toBe(
+      "/docs/datasources/data_source_name",
+    );
+  });
+
+  test("should convert /f/ to /functions/", () => {
+    expect(shortToLongPath("/docs/f/function_name")).toBe(
+      "/docs/functions/function_name",
+    );
+  });
+
+  test("should not affect paths without short forms", () => {
+    expect(shortToLongPath("/docs/overview")).toBe("/docs/overview");
+  });
+});
+
+describe("reworkRelativePaths", () => {
+  test("should not modify provider links with different providers", () => {
+    const input = `[GCP resource](/docs/providers/google/r/compute_instance.html)`;
+    const output = reworkRelativePaths(input, "hashicorp", "aws", "v1.0.0");
+    expect(output).toEqual(input);
+  });
+
+  test("should rework links", () => {
+    const input = `
+    - [\`aws_api_gateway_deployment\` resource](/docs/providers/aws/r/api_gateway_deployment.html)
+    - [\`aws_api_gateway_rest_api\` resource](/docs/providers/aws/r/api_gateway_rest_api.html)
+    - [\`aws_api_gateway_stage\` resource](/docs/providers/aws/r/api_gateway_stage.html)
+    - [\`aws_apigatewayv2_api\` data source](/docs/providers/aws/d/apigatewayv2_api.html)`;
+
+    const output = reworkRelativePaths(input, "hashicorp", "aws", "v1.0.0");
+
+    console.log("output", output);
+
+    const expectedLinks = [
+      "/provider/hashicorp/aws/v1.0.0/docs/resources/api_gateway_deployment",
+      "/provider/hashicorp/aws/v1.0.0/docs/resources/api_gateway_rest_api",
+      "/provider/hashicorp/aws/v1.0.0/docs/resources/api_gateway_stage",
+      "/provider/hashicorp/aws/v1.0.0/docs/datasources/apigatewayv2_api",
+    ];
+    expectedLinks.forEach((link) => {
+      expect(output).toContain(link);
+    });
+  });
+
+  test("should not modify non-docs links", () => {
+    const input =
+      "Check out [our website](https://example.com) for more information.";
+    expect(reworkRelativePaths(input, "hashicorp", "aws", "v1.0.0")).toEqual(
+      input,
+    );
+  });
+
+  test("should process multiple links in the same content", () => {
+    const input = `
+      # Documentation
+      
+      Check out [this resource](/docs/providers/aws/r/resource_name.md) for resource information.
+      
+      More details in [this data source](/docs/providers/aws/d/data_source_name.html#usage).
+      
+      [External link](https://example.com) should remain unchanged.
+    `;
+
+    const output = reworkRelativePaths(input, "hashicorp", "aws", "v1.0.0");
+
+    expect(output).toContain(
+      "/provider/hashicorp/aws/v1.0.0/docs/resources/resource_name",
+    );
+    expect(output).toContain(
+      "/provider/hashicorp/aws/v1.0.0/docs/datasources/data_source_name#user-content-usage",
+    );
+    expect(output).toContain("https://example.com");
+    expect(output).not.toContain("/docs/providers/aws/r/resource_name.md");
+    expect(output).not.toContain("/docs/providers/aws/d/data_source_name.html");
+  });
+
+  test("should handle anchor links correctly", () => {
+    const input = `[EC2 Instance Scheduling](/docs/providers/aws/r/instance.html#scheduling)`;
+    const output = reworkRelativePaths(input, "hashicorp", "aws", "v1.0.0");
+
+    expect(output).toContain(
+      "/provider/hashicorp/aws/v1.0.0/docs/resources/instance#user-content-scheduling",
+    );
+    expect(output).not.toContain(".html");
+  });
+
+  test("should ignore provider links when provider doesn't match", () => {
+    const input = `
+      # Mixed Provider Documentation
+      
+      [AWS Resource](/docs/providers/aws/r/instance.html)
+      [GCP Resource](/docs/providers/google/r/compute_instance.html)
+      [Azure Resource](/docs/providers/azurerm/r/virtual_machine.html)
+    `;
+
+    // When processing AWS provider docs
+    const output = reworkRelativePaths(input, "hashicorp", "aws", "v1.0.0");
+
+    // AWS resources should be transformed
+    expect(output).toContain(
+      "/provider/hashicorp/aws/v1.0.0/docs/resources/instance",
+    );
+
+    // Other provider resources should remain unchanged
+    expect(output).toContain("/docs/providers/google/r/compute_instance.html");
+    expect(output).toContain("/docs/providers/azurerm/r/virtual_machine.html");
+  });
+
+  test("should handle nested directory structures", () => {
+    const input = `[Nested Guide](/docs/providers/aws/guides/iam/policies.html)`;
+    const output = reworkRelativePaths(input, "hashicorp", "aws", "v1.0.0");
+
+    expect(output).toContain(
+      "/provider/hashicorp/aws/v1.0.0/docs/guides/iam/policies",
+    );
+    expect(output).not.toContain(".html");
+  });
+
+  test("should strip extensions from simple filename links", () => {
+    const input = `
+      # Documentation with filename links
+      
+      See [README](README.md) for instructions.
+      Also check [CHANGELOG](CHANGELOG.html) for recent changes.
+      And [LICENSE](LICENSE) doesn't need any changes.
+      Note this [anchor test](README.md#installation) should keep the anchor.
+    `;
+
+    const output = reworkRelativePaths(input, "hashicorp", "aws", "v1.0.0");
+
+    // Extensions should be stripped but filenames preserved
+    expect(output).toContain("[README](README)");
+    expect(output).toContain("[CHANGELOG](CHANGELOG)");
+    expect(output).toContain("[LICENSE](LICENSE)");
+    expect(output).toContain("[anchor test](README#user-content-installation)");
+
+    // Original extensions should be removed
+    expect(output).not.toContain("README.md");
+    expect(output).not.toContain("CHANGELOG.html");
+  });
+});

--- a/frontend/src/routes/Provider/components/docsProcessor.ts
+++ b/frontend/src/routes/Provider/components/docsProcessor.ts
@@ -1,0 +1,140 @@
+// Markdown documentation for terraform providers often contains relative paths to other docs within that provider/module
+// we want to handle this situation, but our pathing is slightly different to the terraform registry
+// so we need to rework the relative paths to point to the correct location
+/*
+  Cases:
+  stripping extensions:
+  - /docs/overview.md -> /docs/overview
+  - /docs/overview.html -> /docs/overview
+
+  anchor links
+  - /docs/overview.md#section -> /docs/overview#section
+  - /docs/overview.html#section -> /docs/overview#section
+
+  directory structure changes:
+  - docs/providers/<providername> -> /provider/<namespace>/<providername>/<version>/docs/
+  - docs/providers/<providername>/r/<resource> -> /provider/<namespace>/<providername>/<version>/docs/resources/<resource>
+  - docs/providers/<providername>/d/<data> -> /provider/<namespace>/<providername>/<version>/docs/datasources/<data>
+*/
+
+type DocProcessor = (
+  path: string,
+  namespace?: string,
+  provider?: string,
+  version?: string,
+) => string;
+
+// stripExtension is used to remove the .md or .html extension from a path
+// but keep the anchor link if it exists
+export const stripExtension: DocProcessor = (path: string): string => {
+  const toStrip = [".md", ".html"];
+  return toStrip.reduce((acc, ext) => {
+    const regex = new RegExp(`(${ext})(#.*)?$`);
+    return acc.replace(regex, "$2");
+  }, path);
+};
+
+// shortToLongPath is used to convert a short path to a long path
+// for example: /r/ -> /resources/
+export const shortToLongPath = (path: string): string => {
+  const shortToLongMap: Record<string, string> = {
+    r: "resources",
+    d: "datasources",
+    f: "functions",
+  };
+
+  const splitPath = path.split("/");
+  for (let i = 0; i < splitPath.length; i++) {
+    const part = splitPath[i];
+    if (shortToLongMap[part]) {
+      splitPath[i] = shortToLongMap[part];
+    }
+  }
+
+  return splitPath.join("/");
+};
+
+// Helper to process a single path through all processors
+const processPath = (
+  path: string,
+  namespace?: string,
+  provider?: string,
+  version?: string,
+): string => {
+  const processors: Array<DocProcessor> = [stripExtension, shortToLongPath];
+
+  return processors.reduce((acc, processor) => {
+    return processor(acc, namespace, provider, version);
+  }, path);
+};
+
+// Helper to add user-content- prefix to anchors in paths as rehypeSanitize has
+// added this prefix to all anchors in the output to avoid clobbering attacks
+export const prefixAnchors = (path: string): string => {
+  const anchorRegex = /#(.*)/;
+  const match = path.match(anchorRegex);
+  if (match) {
+    const anchor = match[1];
+    const newPath = path.replace(anchorRegex, "");
+    return `${newPath}#user-content-${anchor}`;
+  }
+  return path;
+};
+
+export const reworkRelativePaths = (
+  doc: string,
+  namespace: string,
+  provider: string,
+  version: string,
+): string => {
+  // Long links!
+  const linkRegex = /(\[.*?\]\()([^)]+)(\))/g;
+
+  // Iterate across all links
+  const reworked = doc.replace(linkRegex, (match, prefix, path, suffix) => {
+    path = prefixAnchors(path);
+
+    // its just a simple file link, let's not mess with it but just strip the extension
+    if (!path.includes("/")) {
+      const strippedPath = stripExtension(path);
+      return `${prefix}${strippedPath}${suffix}`;
+    }
+
+    // otherwise, we only care about links to /docs/providers
+    if (!path.startsWith("/docs/providers/")) {
+      // If the path doesn't start with /docs/providers/, return the original link
+      return match;
+    }
+
+    // extract the provider names from the path
+    const providerRegex = /\/docs\/providers\/([^/]+)/;
+    const providerMatch = path.match(providerRegex);
+    if (providerMatch) {
+      // Only transform links for the current provider,
+      // if the path is for a different provider, return the original link
+      // its best to not mess with it for now
+      if (providerMatch[1] !== provider) {
+        return match;
+      }
+    }
+
+    const parts = path.split("/");
+    if (parts.length >= 4) {
+      const remainingPath = parts.slice(4).join("/");
+      const processedPath = processPath(
+        `${remainingPath}`,
+        namespace,
+        provider,
+        version,
+      );
+
+      // Transform to registry path structure
+      return `${prefix}/provider/${namespace}/${provider}/${version}/docs/${processedPath}${suffix}`;
+    }
+
+    // Return unmodified if it doesn't match our patterns
+    return prefix + path + suffix;
+  });
+
+  return reworked;
+};


### PR DESCRIPTION
Fixes #54, #279

Previously we had 2 issues.
- Anchor links from rendered markdown were not working correctly
- Relative links designed for the terraform registry were not working in the opentofu registry

This commit adds in a document pre-processor method that will take the markdown and convert the links to a friendlier format.

it will also ensure that any anchor links are correctly formatted to work with rehypeSanitizer.

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] My contribution is compatible with the MPL-2.0 license and I have provided a DCO sign-off on all my commits.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
