### PR TITLE
feat: add provider removal tool and GitHub workflow

### DIFF
--- a/.github/workflows/remove-provider.yml
+++ b/.github/workflows/remove-provider.yml
@@ -1,0 +1,112 @@
+name: Remove Provider from Registry
+
+on:
+  workflow_dispatch:
+    inputs:
+      provider:
+        description: 'Provider to remove (format: namespace/name)'
+        required: true
+        type: string
+      version:
+        description: 'Specific version to remove (leave empty to remove all versions)'
+        required: false
+        type: string
+      dry_run:
+        description: 'Dry run - only show what would be removed'
+        required: false
+        type: boolean
+        default: false
+      environment:
+        description: 'Environment to remove from'
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+
+jobs:
+  remove-provider:
+    name: Remove Provider
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'backend/go.mod'
+          cache-dependency-path: 'backend/go.sum'
+
+      - name: Validate provider format
+        run: |
+          if [[ ! "${{ inputs.provider }}" =~ ^[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+$ ]]; then
+            echo "Error: Invalid provider format. Expected: namespace/name"
+            exit 1
+          fi
+
+      - name: Build remove command
+        working-directory: backend
+        run: go build -o remove ./cmd/remove/
+
+      - name: Remove provider (Dry Run)
+        if: inputs.dry_run == true
+        working-directory: backend
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          AWS_ENDPOINT_URL_S3: ${{ secrets.AWS_ENDPOINT_URL_S3 }}
+        run: |
+          echo "🔍 Running in DRY RUN mode"
+          ./remove \
+            --force \
+            --dry-run \
+            --s3-bucket "${{ secrets.S3_BUCKET }}" \
+            --s3-region "${{ vars.AWS_REGION }}" \
+            ${{ inputs.version && format('--version {0}', inputs.version) || '' }} \
+            provider "${{ inputs.provider }}"
+
+      - name: Remove provider (Actual)
+        if: inputs.dry_run == false
+        working-directory: backend
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ vars.AWS_REGION }}
+          AWS_ENDPOINT_URL_S3: ${{ secrets.AWS_ENDPOINT_URL_S3 }}
+        run: |
+          echo "⚠️  Removing provider ${{ inputs.provider }}"
+          ./remove \
+            --force \
+            --s3-bucket "${{ secrets.S3_BUCKET }}" \
+            --s3-region "${{ vars.AWS_REGION }}" \
+            ${{ inputs.version && format('--version {0}', inputs.version) || '' }} \
+            provider "${{ inputs.provider }}"
+
+      - name: Update search index
+        if: inputs.dry_run == false
+        working-directory: search/pg-indexer
+        env:
+          PG_CONNECTION_STRING: ${{ secrets.PG_CONNECTION_STRING }}
+        run: |
+          echo "📊 Updating search index..."
+          go run ./
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## Remove Provider Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Provider:** ${{ inputs.provider }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version:** ${{ inputs.version || 'All versions' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Environment:** ${{ inputs.environment }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Dry Run:** ${{ inputs.dry_run }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [[ "${{ inputs.dry_run }}" == "true" ]]; then
+            echo "✅ Dry run completed - no changes were made" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "✅ Provider removed successfully" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/remove-provider.yml
+++ b/.github/workflows/remove-provider.yml
@@ -15,7 +15,7 @@ on:
         description: 'Dry run - only show what would be removed'
         required: false
         type: boolean
-        default: false
+        default: true
       environment:
         description: 'Environment to remove from'
         required: true

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,12 @@
 generate-registry:
 	@cd "$(CURDIR)/backend" && go generate ./... && go run ./cmd/generate/ --licenses-file ../licenses.json --destination-dir /tmp/registry --namespace opentofu --name ad
 
+# remove-provider removes a provider from the registry
+# Example: make remove-provider PROVIDER=hashicorp/aws
+# Example with flags: make remove-provider PROVIDER=hashicorp/aws REMOVE_FLAGS="--dry-run --version v1.0.0"
+remove-provider:
+	@cd "$(CURDIR)/backend" && go run ./cmd/remove/ $(REMOVE_FLAGS) provider $(PROVIDER)
+
 # load-registry feed the data from /tmp/registry into the local R2 bucket (search/worker/.wrangler/state/r2) folder
 load-registry:
 	@cd "$(CURDIR)/search/worker" && npm run feed-data

--- a/backend/cmd/remove/main.go
+++ b/backend/cmd/remove/main.go
@@ -1,0 +1,308 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/opentofu/libregistry/logger"
+	"github.com/opentofu/libregistry/types/provider"
+
+	"github.com/opentofu/registry-ui/internal/defaults"
+	"github.com/opentofu/registry-ui/internal/factory"
+	"github.com/opentofu/registry-ui/internal/indexstorage"
+	"github.com/opentofu/registry-ui/internal/indexstorage/bufferedstorage"
+	"github.com/opentofu/registry-ui/internal/indexstorage/filesystemstorage"
+	"github.com/opentofu/registry-ui/internal/indexstorage/s3storage"
+	"github.com/opentofu/registry-ui/internal/providerindex/providerindexstorage"
+	"github.com/opentofu/registry-ui/internal/search"
+	"github.com/opentofu/registry-ui/internal/search/searchstorage/indexstoragesearch"
+	"github.com/opentofu/registry-ui/internal/search/searchtypes"
+)
+
+func main() {
+	var (
+		resourceType   string
+		resourceAddr   string
+		version        string
+		force          bool
+		dryRun         bool
+		logLevel       = "info"
+		destinationDir = defaults.DestinationDir
+	)
+	s3Params := factory.S3Parameters{
+		AccessKey:  os.Getenv("AWS_ACCESS_KEY_ID"),
+		SecretKey:  os.Getenv("AWS_SECRET_ACCESS_KEY"),
+		Region:     os.Getenv("AWS_REGION"),
+		CACertFile: os.Getenv("AWS_CA_BUNDLE"),
+		Endpoint:   os.Getenv("AWS_ENDPOINT_URL_S3"),
+	}
+	if s3Params.Endpoint == "" {
+		s3Params.Endpoint = os.Getenv("AWS_ENDPOINT_URL")
+	}
+
+	flag.StringVar(&logLevel, "log-level", logLevel, "Set the log level (debug, info, warn, error)")
+	flag.StringVar(&destinationDir, "destination-dir", destinationDir, "Directory to place generated documentation and indexes in.")
+	flag.StringVar(&s3Params.Bucket, "s3-bucket", s3Params.Bucket, "S3 bucket to use for uploads.")
+	flag.StringVar(&s3Params.Endpoint, "s3-endpoint", s3Params.Endpoint, "S3 endpoint to use for uploads. Defaults to AWS.")
+	flag.BoolVar(&s3Params.PathStyle, "s3-path-style", s3Params.PathStyle, "Use path-style URLs for S3.")
+	flag.StringVar(&s3Params.CACertFile, "s3-ca-cert-file", s3Params.CACertFile, "File containing the CA certificate for the S3 endpoint. Defaults to the system certificates.")
+	flag.StringVar(&s3Params.Region, "s3-region", s3Params.Region, "Region to use for S3 uploads.")
+	flag.StringVar(&version, "version", version, "Specific version to remove (optional, removes all versions if not specified)")
+	flag.BoolVar(&force, "force", force, "Skip confirmation prompt")
+	flag.BoolVar(&dryRun, "dry-run", dryRun, "Show what would be removed without actually removing")
+	flag.Parse()
+
+	// Parse command arguments
+	args := flag.Args()
+	if len(args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s <resource-type> <resource-address> [flags]\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Resource types: provider\n")
+		fmt.Fprintf(os.Stderr, "Example: %s provider hashicorp/aws\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	resourceType = args[0]
+	resourceAddr = args[1]
+
+	// Validate resource type
+	if resourceType != "provider" {
+		fmt.Fprintf(os.Stderr, "Error: unsupported resource type '%s'. Only 'provider' is currently supported.\n", resourceType)
+		os.Exit(1)
+	}
+
+	// Parse the log level
+	level, err := parseLogLevel(logLevel)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
+		os.Exit(1)
+	}
+	mainLogger := logger.NewSLogLogger(slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: level,
+	})))
+
+	ctx := context.Background()
+
+	// TODO: Extend to modules too, not just providers
+
+	// Parse and validate provider address
+	providerAddr := provider.Addr{
+		Namespace: strings.Split(resourceAddr, "/")[0],
+		Name:      strings.Split(resourceAddr, "/")[1],
+	}
+	if len(strings.Split(resourceAddr, "/")) != 2 {
+		mainLogger.Error(ctx, "Invalid provider address format. Expected: namespace/name")
+		os.Exit(1)
+	}
+
+	mainLogger.Info(ctx, "Initializing storage systems...")
+
+	// Create temporary directory for buffered storage
+	localDir, err := os.MkdirTemp("", "registry-remove-*")
+	if err != nil {
+		mainLogger.Error(ctx, "Failed to create temporary directory: %v", err)
+		os.Exit(1)
+	}
+	defer func() {
+		if err := os.RemoveAll(localDir); err != nil {
+			mainLogger.Warn(ctx, "Failed to clean up temporary directory %s: %v", localDir, err)
+		}
+	}()
+
+	backingStorage, err := getBackingStorage(ctx, mainLogger, s3Params, destinationDir)
+	if err != nil {
+		os.Exit(1)
+	}
+
+	bufferedStorage, err := bufferedstorage.New(mainLogger, localDir, backingStorage, 100)
+	if err != nil {
+		mainLogger.Error(ctx, "Failed to create buffered storage: %v", err)
+		os.Exit(1)
+	}
+
+	providerStorageDir, err := bufferedStorage.Subdirectory(ctx, "providers")
+	if err != nil {
+		mainLogger.Error(ctx, "Failed to get provider storage directory: %v", err)
+		os.Exit(1)
+	}
+	providerStorage, err := providerindexstorage.New(providerStorageDir)
+	if err != nil {
+		mainLogger.Error(ctx, "Failed to create provider storage: %v", err)
+		os.Exit(1)
+	}
+
+	searchStorage, err := indexstoragesearch.New(bufferedStorage)
+	if err != nil {
+		mainLogger.Error(ctx, "Failed to create search storage: %v", err)
+		os.Exit(1)
+	}
+
+	searchAPI, err := search.New(searchStorage, search.WithLogger(mainLogger))
+	if err != nil {
+		mainLogger.Error(ctx, "Failed to create search API: %v", err)
+		os.Exit(1)
+	}
+
+	// Check if provider exists and get its versions
+	providerData, err := providerStorage.GetProvider(ctx, providerAddr)
+	if err != nil {
+		mainLogger.Error(ctx, "Provider %s not found in registry: %v", providerAddr, err)
+		os.Exit(1)
+	}
+
+	var removeMessage string
+	if version != "" {
+		removeMessage = fmt.Sprintf("provider %s version %s", providerAddr, version)
+	} else {
+		removeMessage = fmt.Sprintf("provider %s and ALL its versions", providerAddr)
+	}
+
+	// Dry run mode
+	if dryRun {
+		mainLogger.Info(ctx, "DRY RUN: Would remove %s", removeMessage)
+
+		if version == "" {
+			// List all versions that would be removed
+			mainLogger.Info(ctx, "DRY RUN: Would remove %d versions:", len(providerData.Versions))
+			for _, v := range providerData.Versions {
+				mainLogger.Info(ctx, "  - %s", v.ID)
+			}
+		} else {
+			mainLogger.Info(ctx, "DRY RUN: No changes made")
+		}
+		os.Exit(0)
+	}
+
+	// Confirmation prompt (unless --force)
+	if !force {
+		fmt.Printf("Are you sure you want to remove %s? [y/N]: ", removeMessage)
+		reader := bufio.NewReader(os.Stdin)
+		response, err := reader.ReadString('\n')
+		if err != nil {
+			mainLogger.Error(ctx, "Failed to read response: %v", err)
+			os.Exit(1)
+		}
+
+		response = strings.TrimSpace(strings.ToLower(response))
+		if response != "y" && response != "yes" {
+			mainLogger.Info(ctx, "Operation cancelled")
+			os.Exit(0)
+		}
+	}
+
+	// Perform the removal
+	var versionsToRemove []provider.VersionNumber
+	if version != "" {
+		versionsToRemove = append(versionsToRemove, provider.VersionNumber(version))
+		mainLogger.Info(ctx, "Removing provider %s version %s...", providerAddr, version)
+	} else {
+		for _, v := range providerData.Versions {
+			versionsToRemove = append(versionsToRemove, v.ID)
+		}
+		mainLogger.Info(ctx, "Removing provider %s and all %d versions...", providerAddr, len(versionsToRemove))
+	}
+
+	// Remove each version from search index
+	for _, v := range versionsToRemove {
+		mainLogger.Debug(ctx, "Removing version %s from search index...", v)
+		if err := searchAPI.RemoveVersionItems(ctx, searchtypes.IndexTypeProvider, providerAddr.String(), string(v)); err != nil {
+			mainLogger.Error(ctx, "Failed to remove version %s from search index: %v", v, err)
+			os.Exit(1)
+		}
+		if err := providerStorage.DeleteProviderVersion(ctx, providerAddr, v); err != nil {
+			mainLogger.Error(ctx, "Failed to remove provider version: %v", err)
+			os.Exit(1)
+		}
+	}
+
+	// Remove from provider storage when we dont specify a version
+	if version == "" {
+		if err := providerStorage.DeleteProvider(ctx, providerAddr); err != nil {
+			mainLogger.Error(ctx, "Failed to remove provider: %v", err)
+			os.Exit(1)
+		}
+		mainLogger.Info(ctx, "Successfully removed provider %s (%d versions)", providerAddr, len(versionsToRemove))
+	}
+
+	// Commit the changes
+	mainLogger.Info(ctx, "Committing changes...")
+	if err := bufferedStorage.Commit(ctx); err != nil {
+		mainLogger.Error(ctx, "Failed to commit changes: %v", err)
+		os.Exit(1)
+	}
+
+	mainLogger.Info(ctx, "Done!")
+}
+
+func getBackingStorage(ctx context.Context, mainLogger logger.Logger, s3Params factory.S3Parameters, destinationDir string) (indexstorage.API, error) {
+	var backingStorage indexstorage.API
+	var err error
+	if s3Params.Bucket != "" {
+		var tlsPool *x509.CertPool
+		if s3Params.CACertFile != "" {
+			cacert, err := os.ReadFile(s3Params.CACertFile)
+			if err != nil {
+				mainLogger.Error(ctx, "Failed to read CA cert file: %v", err)
+				os.Exit(1)
+			}
+			tlsPool = x509.NewCertPool()
+			if !tlsPool.AppendCertsFromPEM(cacert) {
+				mainLogger.Error(ctx, "Failed to parse CA cert")
+				os.Exit(1)
+			}
+		} else {
+			tlsPool, err = x509.SystemCertPool()
+			if err != nil {
+				mainLogger.Error(ctx, "System cert pool not available: %v", err)
+				os.Exit(1)
+			}
+		}
+		backingStorage, err = s3storage.New(
+			ctx,
+			s3storage.WithBucket(s3Params.Bucket),
+			s3storage.WithRegion(s3Params.Region),
+			s3storage.WithEndpoint(s3Params.Endpoint),
+			s3storage.WithPathStyle(s3Params.PathStyle),
+			s3storage.WithTLSConfig(&tls.Config{
+				RootCAs: tlsPool,
+			}),
+			s3storage.WithAccessKey(s3Params.AccessKey),
+			s3storage.WithSecretKey(s3Params.SecretKey),
+		)
+		if err != nil {
+			mainLogger.Error(ctx, "Failed to create S3 storage: %v", err)
+			os.Exit(1)
+		}
+	} else {
+		backingStorage, err = filesystemstorage.New(destinationDir)
+		if err != nil {
+			mainLogger.Error(ctx, "Failed to create filesystem storage: %v", err)
+			os.Exit(1)
+		}
+	}
+	return backingStorage, err
+}
+
+func parseLogLevel(level string) (slog.Level, error) {
+	switch level {
+	case "trace":
+		// This is a custom log level in libregistry.
+		return -8, nil
+	case "debug":
+		return slog.LevelDebug, nil
+	case "info":
+		return slog.LevelInfo, nil
+	case "warn":
+		return slog.LevelWarn, nil
+	case "error":
+		return slog.LevelError, nil
+	default:
+		return slog.LevelDebug, fmt.Errorf("unknown log level: %s", level)
+	}
+}


### PR DESCRIPTION
- Add new remove command under backend/cmd/remove/ for removing providers
- Add GitHub Actions workflow for manual provider removal with dry-run option
- Add Makefile target 'remove-provider' for local usage
- Support removing specific versions or all versions of a provider


## Checklist

- [ ] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [ ] I have not used an AI coding assistant to create this PR.
- [ ] My contribution is compatible with the MPL-2.0 license and I have provided a DCO sign-off on all my commits.
- [ ] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
