### PR TITLE
Strip more Markdown file extensions

### DIFF
--- a/frontend/src/routes/Provider/components/docsProcessor.test.ts
+++ b/frontend/src/routes/Provider/components/docsProcessor.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+  extensionsToStrip,
   stripExtension,
   shortToLongPath,
   reworkRelativePaths,
@@ -7,25 +8,21 @@ import {
 } from "./docsProcessor";
 
 describe("stripExtension", () => {
-  test("should strip .md extension", () => {
-    expect(stripExtension("/docs/overview.md")).toBe("/docs/overview");
-  });
-
-  test("should strip .html extension", () => {
-    expect(stripExtension("/docs/overview.html")).toBe("/docs/overview");
+  extensionsToStrip.forEach((extension) => {
+    test(`should strip ${extension} extensions`, () => {
+      expect(stripExtension(`/docs/overview${extension}`)).toBe(
+        "/docs/overview",
+      );
+    });
+    test(`should handle paths with ${extension} extensions and anchor links`, () => {
+      expect(stripExtension(`/docs/overview${extension}#section`)).toBe(
+        "/docs/overview#section",
+      );
+    });
   });
 
   test("should not affect paths without extensions", () => {
     expect(stripExtension("/docs/overview")).toBe("/docs/overview");
-  });
-
-  test("should handle paths with anchor links", () => {
-    expect(stripExtension("/docs/overview.md#section")).toBe(
-      "/docs/overview#section",
-    );
-    expect(stripExtension("/docs/overview.html#section")).toBe(
-      "/docs/overview#section",
-    );
   });
 });
 

--- a/frontend/src/routes/Provider/components/docsProcessor.ts
+++ b/frontend/src/routes/Provider/components/docsProcessor.ts
@@ -24,11 +24,20 @@ type DocProcessor = (
   version?: string,
 ) => string;
 
-// stripExtension is used to remove the .md or .html extension from a path
+export const extensionsToStrip = [
+  ".html.markdown",
+  ".html.md",
+  ".html",
+  ".markdown.html",
+  ".markdown",
+  ".md.html",
+  ".md",
+];
+
+// stripExtension is used to remove extensions from a path
 // but keep the anchor link if it exists
 export const stripExtension: DocProcessor = (path: string): string => {
-  const toStrip = [".md", ".html"];
-  return toStrip.reduce((acc, ext) => {
+  return extensionsToStrip.reduce((acc, ext) => {
     const regex = new RegExp(`(${ext})(#.*)?$`);
     return acc.replace(regex, "$2");
   }, path);


### PR DESCRIPTION
## Description

Fixes https://github.com/opentofu/registry-ui/issues/342

OpenTofu provider documentation files can have [several different file extensions](https://github.com/opentofu/registry-ui/blob/main/documentation/documentation-sources.md#normalization-process).

The backend scraper handles the complete list of these extensions:

https://github.com/opentofu/registry-ui/blob/c4ea85ab9a4c077a31440f694991050daf8fe6ab/backend/internal/providerindex/providerdocsource/scrape.go#L241-L248

However, the frontend docs processor only handles `.html` and `.md`:

https://github.com/opentofu/registry-ui/blob/c4ea85ab9a4c077a31440f694991050daf8fe6ab/frontend/src/routes/Provider/components/docsProcessor.ts#L27-L30

As a result, extensions like `.html.markdown` are left in relative links in the files, resulting in broken links (#342).

## Changes

This PR will provide a follow-up to https://github.com/opentofu/registry-ui/pull/327 by stripping more extensions from Markdown relative links.

## Related

- https://github.com/opentofu/registry-ui/issues/279
- https://github.com/opentofu/registry-ui/pull/327
- https://github.com/opentofu/registry-ui/issues/342

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] My contribution is compatible with the MPL-2.0 license and I have provided a DCO sign-off on all my commits.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
