### PR TITLE
docs: Fix up headings on provider documentation page

### DIFF
--- a/frontend/docs/providers/docs.md
+++ b/frontend/docs/providers/docs.md
@@ -35,10 +35,10 @@ While you can put any metadata in the header, the following fields are used by t
 
 Title of the registry UI webpage (and some meta tags).
 
-### description
+#### description
 
 Description, used in html meta tags in the registry UI.
 
-### subcategory
+#### subcategory
 
 Subcategory can be used to group resources, which is reflected in the UI sidebar. It adds categories in addition to the default `Resources`, `Datasources`, etc.


### PR DESCRIPTION
There's currently a mismatch of subheadings in the "Metadata" section of the "Writing documentation for your provider" page. The first subheading is level 4, but the remaining 2 revert back to level 3. The resulting page looks out of whack:

<img width="1082" height="606" alt="opentofu-provider-docs-broken-page" src="https://github.com/user-attachments/assets/92665d8b-4765-443c-8ad3-6c55f04e3374" />


## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] My contribution is compatible with the MPL-2.0 license and I have provided a DCO sign-off on all my commits.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
