### PR TITLE
Fixed missing ToC on docs pages and overviews for providers

### DIFF
--- a/frontend/src/components/Markdown/index.tsx
+++ b/frontend/src/components/Markdown/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { processor } from "./processor";
 
 interface MarkdownProps {
@@ -20,8 +20,7 @@ export function Markdown({ text, onTocExtracted }: MarkdownProps) {
     return { result: file.result, toc };
   }, [text]);
 
-  // Call the callback with TOC data when it changes
-  useMemo(() => {
+  useEffect(() => {
     if (onTocExtracted) {
       onTocExtracted(toc);
     }

--- a/frontend/src/routes/Provider/index.tsx
+++ b/frontend/src/routes/Provider/index.tsx
@@ -1,4 +1,4 @@
-import { Outlet, useLocation } from "react-router";
+import { Outlet } from "react-router";
 import { SidebarLayout } from "../../components/SidebarLayout";
 import { SidebarPanel } from "../../components/SidebarPanel";
 import { Suspense } from "react";
@@ -28,9 +28,6 @@ import {
 } from "./components/TableOfContents";
 
 export function Provider() {
-  const location = useLocation();
-  const isDocsPage = location.pathname.includes("/docs/");
-
   return (
     <DocsProvider>
       <SidebarLayout
@@ -54,11 +51,9 @@ export function Provider() {
             >
               <ProviderVersionsSidebarBlock />
               <ProviderInstructionSidebarBlock />
-              {isDocsPage && (
-                <Suspense fallback={<TableOfContentsSkeleton />}>
-                  <TableOfContents />
-                </Suspense>
-              )}
+              <Suspense fallback={<TableOfContentsSkeleton />}>
+                <TableOfContents />
+              </Suspense>
             </Suspense>
           </SidebarPanel>
         }


### PR DESCRIPTION
This ensures the table of contents ("On this page") is displayed for all provider documentation.

<img width="635" height="874" alt="image" src="https://github.com/user-attachments/assets/2e263e4d-0176-45c9-b368-ef7c5b272955" />

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] My contribution is compatible with the MPL-2.0 license and I have provided a DCO sign-off on all my commits.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
