### PR TITLE
Use correct url for finding avatars

### DIFF
--- a/frontend/src/components/Search/ModuleResult.tsx
+++ b/frontend/src/components/Search/ModuleResult.tsx
@@ -11,7 +11,7 @@ export function SearchModuleResult({ result }: SearchModuleResultProps) {
     <div className="flex items-start gap-3">
       {namespace && (
         <img
-          src={`https://avatars.githubusercontent.com/${namespace}`}
+          src={`https://github.com/${namespace}.png`}
           alt={`${namespace} avatar`}
           className="h-8 w-8 flex-shrink-0 rounded ring-1 ring-gray-200 dark:ring-gray-700"
           onError={(e) => {

--- a/frontend/src/components/Search/ProviderResult.tsx
+++ b/frontend/src/components/Search/ProviderResult.tsx
@@ -11,7 +11,7 @@ export function SearchProviderResult({ result }: SearchProviderResultProps) {
     <div className="flex items-start gap-3">
       {namespace && (
         <img
-          src={`https://avatars.githubusercontent.com/${namespace}`}
+          src={`https://github.com/${namespace}.png`}
           alt={`${namespace} avatar`}
           className="h-8 w-8 flex-shrink-0 rounded ring-1 ring-gray-200 dark:ring-gray-700"
           onError={(e) => {

--- a/frontend/src/routes/Home/components/ResultItem.tsx
+++ b/frontend/src/routes/Home/components/ResultItem.tsx
@@ -21,7 +21,7 @@ export function ResultItem({ result, isSelected, onClick }: ResultItemProps) {
     >
       <div className="mt-0.5 flex-shrink-0">
         <img
-          src={`https://avatars.githubusercontent.com/${result.link_variables.namespace}`}
+          src={`https://github.com/${result.link_variables.namespace}.png`}
           alt=""
           className="h-5 w-5 rounded"
           loading="lazy"

--- a/frontend/src/routes/Modules/components/CardItem.tsx
+++ b/frontend/src/routes/Modules/components/CardItem.tsx
@@ -25,7 +25,7 @@ export function ModulesCardItem({ module }: ModulesCardItemProps) {
           className="flex-shrink-0"
         >
           <img
-            src={`https://avatars.githubusercontent.com/${module.addr.namespace}`}
+            src={`https://github.com/${module.addr.namespace}.png`}
             alt={`${module.addr.namespace} avatar`}
             className="h-10 w-10 rounded-lg ring-1 ring-gray-200 dark:ring-gray-700"
             loading="lazy"

--- a/frontend/src/routes/Providers/components/CardItem.tsx
+++ b/frontend/src/routes/Providers/components/CardItem.tsx
@@ -29,7 +29,7 @@ export function ProvidersCardItem({ provider }: ProviderCardItemProps) {
           className="flex-shrink-0"
         >
           <img
-            src={`https://avatars.githubusercontent.com/${provider.addr.namespace}`}
+            src={`https://github.com/${provider.addr.namespace}.png`}
             alt={`${provider.addr.namespace} avatar`}
             className="h-10 w-10 rounded-lg ring-1 ring-gray-200 dark:ring-gray-700"
             loading="lazy"


### PR DESCRIPTION
Apparently https://avatars.githubusercontent.com/ is no bueno. Let's use github.com/<namespace>.png instead.

Before (octocats for non-personal github accounts, ie orgs):
<img width="348" height="809" alt="image" src="https://github.com/user-attachments/assets/ee50cbce-aaf1-4f25-8b2d-aae1cdbe5b73" />


After:
<img width="331" height="805" alt="image" src="https://github.com/user-attachments/assets/4bbff6ac-f386-4ee6-9204-f1df036c4863" />


## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] My contribution is compatible with the MPL-2.0 license and I have provided a DCO sign-off on all my commits.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
