### PR TITLE
Provider v2: Only make a single upload manager, fix connections being unlimited

### DIFF
--- a/backendv2/pkg/config/bucket.go
+++ b/backendv2/pkg/config/bucket.go
@@ -54,7 +54,7 @@ func (c *BucketConfig) GetClient(ctx context.Context) (*s3.Client, error) {
 		// Connection pool settings - critical for performance
 		MaxIdleConns:        200,              // Total max idle connections
 		MaxIdleConnsPerHost: 200,              // Max idle connections per host (default is only 2!)
-		MaxConnsPerHost:     0,                // No limit on connections per host
+		MaxConnsPerHost:     200,              // excess uploads queue here instead of flooding R2 with sockets (R2 refuses connections / throttles under unbounded concurrency)
 		IdleConnTimeout:     90 * time.Second, // Keep connections alive longer
 
 		// Timeouts
@@ -93,6 +93,8 @@ func (c *BucketConfig) GetClient(ctx context.Context) (*s3.Client, error) {
 		if c.Endpoint != "" {
 			o.BaseEndpoint = aws.String(c.Endpoint)
 		}
+		o.RetryMode = aws.RetryModeAdaptive
+		o.RetryMaxAttempts = 10
 	})
 
 	c.client = client

--- a/backendv2/pkg/provider/indexer.go
+++ b/backendv2/pkg/provider/indexer.go
@@ -106,7 +106,7 @@ func (p *ProviderReader) IndexVersion(ctx context.Context, provider *registry.Pr
 	}
 
 	// Create documentation scraper
-	docScraper := scraper.New(p.config, p.s3Client, p.db)
+	docScraper := scraper.New(p.config, p.uploader, p.db)
 
 	// Initialize doc count and docs
 	var docCount int

--- a/backendv2/pkg/provider/scraper/docs.go
+++ b/backendv2/pkg/provider/scraper/docs.go
@@ -75,16 +75,14 @@ type DocItem struct {
 
 type Scraper struct {
 	config   *config.BackendConfig
-	s3Client *s3.Client
 	uploader *manager.Uploader
 	pool     *pgxpool.Pool
 }
 
-func New(cfg *config.BackendConfig, s3Client *s3.Client, pool *pgxpool.Pool) *Scraper {
+func New(cfg *config.BackendConfig, uploader *manager.Uploader, pool *pgxpool.Pool) *Scraper {
 	return &Scraper{
 		config:   cfg,
-		s3Client: s3Client,
-		uploader: manager.NewUploader(s3Client),
+		uploader: uploader,
 		pool:     pool,
 	}
 }

--- a/backendv2/pkg/provider/scraper/docs_test.go
+++ b/backendv2/pkg/provider/scraper/docs_test.go
@@ -131,8 +131,7 @@ Manages projects.
 
 	for _, tt := range tests {
 		s := &Scraper{
-			config:   nil,
-			s3Client: nil,
+			config: nil,
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			doc := &DocItem{}


### PR DESCRIPTION
Unlimited connections was a bad idea. let's max it out at 200.

This also ensures that we dont create a lot of upload managers, and instead we pass around a single manager similar to modules.

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] My contribution is compatible with the MPL-2.0 license and I have provided a DCO sign-off on all my commits.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
