### PR TITLE
Enable worker telemetry destinations for the search worker

### DIFF
--- a/search/worker/wrangler.toml
+++ b/search/worker/wrangler.toml
@@ -22,6 +22,8 @@ invocation_logs = true
 
 [observability.traces]
 enabled = true
+head_sampling_rate = 1
+destinations = [ "worker-traces" ]
 
 [cache]
 enabled = true


### PR DESCRIPTION
This allows us to aggregate the data from the obversability tracing that cloudflare has added to workers lately.

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] My contribution is compatible with the MPL-2.0 license and I have provided a DCO sign-off on all my commits.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
