### PR TITLE
Introduce backendv2 module syncing, re-work some of the GHA

### DIFF
--- a/.github/workflows/backendv2-run.yml
+++ b/.github/workflows/backendv2-run.yml
@@ -1,0 +1,73 @@
+name: Backend v2 - run command
+on:
+  workflow_call:
+    inputs:
+      command:
+        description: "backendv2 CLI command (and args) to run, e.g. 'sync-providers' or 'migrate up'"
+        required: true
+        type: string
+      needs_tofu:
+        description: "Whether this command needs the OpenTofu nightly binary available"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  run:
+    name: Run ${{ inputs.command }}
+    runs-on: ubuntu-latest
+    environment: backendv2
+    defaults:
+      run:
+        working-directory: backendv2
+    services:
+      # Spawn the datadog agent for this, based on https://github.com/DataDog/KubeHound/blob/3df6840dcde9acde35294fb8dece2b8ec6002536/.github/workflows/system-test.yml#L17-L27
+      dd-agent:
+        image: gcr.io/datadoghq/agent:7
+        env:
+          DD_API_KEY: ${{ secrets.DD_API_KEY }}
+          DD_TRACE_DEBUG: 0
+          DD_LOGS_ENABLED: true
+          DD_APM_ENABLED: true
+          DD_APM_NON_LOCAL_TRAFFIC: true
+          DD_OTLP_CONFIG_LOGS_ENABLED: true
+          DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT: "0.0.0.0:4317"
+          DD_HOSTNAME: "index-v2-github-actions"
+          DD_SITE: "datadoghq.eu"
+        ports:
+          - 4317:4317
+    env:
+      REGISTRY_WORKDIR: "/tmp/opentofu-registry-backend"
+      REGISTRY_REGISTRYPATH: "/tmp/opentofu-registry-backend/registry"
+      REGISTRY_BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
+      REGISTRY_BUCKET_ACCESSKEYID: ${{ secrets.BUCKET_ACCESSKEYID }}
+      REGISTRY_BUCKET_SECRETACCESSKEY: ${{ secrets.BUCKET_SECRETACCESSKEY }}
+      REGISTRY_BUCKET_ENDPOINT: ${{ secrets.BUCKET_ENDPOINT }}
+      REGISTRY_BUCKET_REGION: "auto"
+      REGISTRY_DB_CONNECTIONSTRING: ${{ secrets.DB_CONNECTIONSTRING }}
+      REGISTRY_GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      REGISTRY_TELEMETRY_ENABLED: "true"
+      REGISTRY_TELEMETRY_LOGGING: "true"
+      REGISTRY_TELEMETRY_EXPORTER: "otlp"
+      REGISTRY_TELEMETRY_ENDPOINT: "localhost:4317"
+      REGISTRY_TELEMETRY_SERVICENAME: "opentofu-registry-backendv2"
+      REGISTRY_TELEMETRY_INSECURE: "true"
+    steps:
+      - name: Checkout Git Repo
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: backendv2/go.mod
+          cache: true
+
+      - name: Build CLI
+        run: go build -o backendv2
+
+      - name: Setup OpenTofu - Nightly
+        if: ${{ inputs.needs_tofu }}
+        run: ./backendv2 dl-tofu-nightly
+
+      - name: Run command
+        run: ./backendv2 ${{ inputs.command }}

--- a/.github/workflows/index-v2.yml
+++ b/.github/workflows/index-v2.yml
@@ -4,66 +4,43 @@ on:
 
 concurrency:
   group: backendv2
+
 jobs:
-  sync:
-    name: Run V2 Backend Documentation Index
-    runs-on: ubuntu-latest
-    environment: backendv2
-    defaults:
-      run:
-        working-directory: backendv2
-    services:
-      # Spawn the datadog agent for this, based on https://github.com/DataDog/KubeHound/blob/3df6840dcde9acde35294fb8dece2b8ec6002536/.github/workflows/system-test.yml#L17-L27
-      dd-agent:
-        image: gcr.io/datadoghq/agent:7
-        env:
-          DD_API_KEY: ${{ secrets.DD_API_KEY }}
-          DD_TRACE_DEBUG: 0
-          DD_LOGS_ENABLED: true
-          DD_APM_ENABLED: true
-          DD_APM_NON_LOCAL_TRAFFIC: true
-          DD_OTLP_CONFIG_LOGS_ENABLED: true
-          DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT: "0.0.0.0:4317"
-          DD_HOSTNAME: "index-v2-github-actions"
-          DD_SITE: "datadoghq.eu"
-        ports:
-          - 4317:4317
-    env:
-      # Env for the steps
-      REGISTRY_WORKDIR: "/tmp/opentofu-registry-backend"
-      REGISTRY_REGISTRYPATH: "/tmp/opentofu-registry-backend/registry"
-      REGISTRY_BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
-      REGISTRY_BUCKET_ACCESSKEYID: ${{ secrets.BUCKET_ACCESSKEYID }}
-      REGISTRY_BUCKET_SECRETACCESSKEY: ${{ secrets.BUCKET_SECRETACCESSKEY }}
-      REGISTRY_BUCKET_ENDPOINT: ${{ secrets.BUCKET_ENDPOINT }}
-      REGISTRY_BUCKET_REGION: "auto"
-      REGISTRY_DB_CONNECTIONSTRING: ${{ secrets.DB_CONNECTIONSTRING }}
-      REGISTRY_GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-      REGISTRY_TELEMETRY_ENABLED: "true"
-      REGISTRY_TELEMETRY_LOGGING: "true"
-      REGISTRY_TELEMETRY_EXPORTER: "otlp"
-      REGISTRY_TELEMETRY_ENDPOINT: "localhost:4317"
-      REGISTRY_TELEMETRY_SERVICENAME: "opentofu-registry-backendv2"
-      REGISTRY_TELEMETRY_INSECURE: "true"
-    steps:
-      - name: Checkout Git Repo
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+  migrate:
+    name: Migrate the DB
+    uses: ./.github/workflows/backendv2-run.yml
+    secrets: inherit
+    with:
+      command: migrate up
 
-      - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: backendv2/go.mod
-          cache: true
+  sync-providers:
+    name: Sync Providers
+    needs: migrate
+    uses: ./.github/workflows/backendv2-run.yml
+    secrets: inherit
+    with:
+      command: sync-providers
 
-      - name: Build CLI
-        run: go build -o backendv2
+  sync-modules:
+    name: Sync Modules
+    needs: migrate
+    uses: ./.github/workflows/backendv2-run.yml
+    secrets: inherit
+    with:
+      command: sync-modules
+      needs_tofu: true
 
-      - name: Setup OpenTofu - Nightly
-        run: ./backendv2 dl-tofu-nightly
-
-      - name: Migrate the DB
-        run: ./backendv2 migrate up
-
-      - name: Index
-        run: ./backendv2 sync-providers
-        # TODO: Once this runs, introduce other commands
+  rebuild-global-indexes:
+    name: Rebuild Global Indexes
+    needs:
+      - sync-providers
+      - sync-modules
+    # Publish whatever is already in the DB even if one sync job failed
+    # (e.g. a transient Datadog/OTLP or GitHub API error), so a problem in
+    # one pipeline doesn't also block the other pipeline's index update.
+    # Only manual cancellation should skip this.
+    if: ${{ !cancelled() }}
+    uses: ./.github/workflows/backendv2-run.yml
+    secrets: inherit
+    with:
+      command: rebuild-global-indexes

--- a/backendv2/command/sync-modules/command.go
+++ b/backendv2/command/sync-modules/command.go
@@ -29,7 +29,7 @@ func NewCommand() *cli.Command {
 				Name:     "filter",
 				Aliases:  []string{"f"},
 				Usage:    "Module filter pattern (e.g., 'hashicorp/*', '*/vpc', 'hashicorp/vpc/aws'). Supports wildcards.",
-				Required: true,
+				Required: false,
 			},
 			&cli.StringFlag{
 				Name:     "version",


### PR DESCRIPTION
This commit 
- adds module syncin
- removes the filter as a mandatory arg for the `sync-modules` cmd
-  and moves GHA logic around to a re-usable workflow to make the DD agent spinning up a bit easier

Assisted-by: GitHub Copilot (Model: claude-sonnet-5)

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [ ] I have not used an AI coding assistant to create this PR.
- [x] My contribution is compatible with the MPL-2.0 license and I have provided a DCO sign-off on all my commits.
- [ ] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
