### PR TITLE
Resolve issues with provider deletion not working correctly

### DIFF
--- a/backend/cmd/remove/main.go
+++ b/backend/cmd/remove/main.go
@@ -230,11 +230,11 @@ func main() {
 
 	// Check if we need to remove the provider entirely
 	shouldRemoveFromList := false
-	
+
 	if version == "" {
 		// Removing all versions - definitely remove from list
 		shouldRemoveFromList = true
-		
+
 		if err := providerStorage.DeleteProvider(ctx, providerAddr); err != nil {
 			mainLogger.Error(ctx, "Failed to remove provider: %v", err)
 			os.Exit(1)
@@ -246,30 +246,31 @@ func main() {
 			os.Exit(1)
 		}
 	} else {
-		// Check if this was the last version
-		remainingProvider, err := providerStorage.GetProvider(ctx, providerAddr)
-		if err != nil {
-			mainLogger.Error(ctx, "Failed to check remaining versions: %v", err)
+		removed := map[provider.VersionNumber]struct{}{}
+		for _, v := range versionsToRemove {
+			// store the version we're removing
+			removed[v.Normalize()] = struct{}{}
+		}
+		// filter the list of versions so we can re-store this without the removed item.
+		filteredVersions := providerData.Versions[:0]
+		for _, ver := range providerData.Versions {
+			if _, ok := removed[ver.ID.Normalize()]; !ok {
+				filteredVersions = append(filteredVersions, ver)
+			}
+		}
+		providerData.Versions = filteredVersions
+
+		// store it
+		if err := providerStorage.StoreProvider(ctx, providerData); err != nil {
+			mainLogger.Error(ctx, "Failed to update provider index: %v", err)
 			os.Exit(1)
 		}
-		
-		if len(remainingProvider.Versions) == 0 {
-			// This was the last version, remove the provider entirely
+		if len(providerData.Versions) == 0 {
 			shouldRemoveFromList = true
-			mainLogger.Info(ctx, "Removed last version of provider %s, removing provider entirely", providerAddr)
-			
-			if err := providerStorage.DeleteProvider(ctx, providerAddr); err != nil {
-				mainLogger.Error(ctx, "Failed to remove provider: %v", err)
-				os.Exit(1)
-			}
-			
-			if err := searchAPI.RemoveItem(ctx, searchtypes.IndexID("providers/"+providerAddr.String())); err != nil {
-				mainLogger.Error(ctx, "Failed to remove provider from search index: %v", err)
-				os.Exit(1)
-			}
 		}
+		mainLogger.Info(ctx, "Updated provider %s index, removed %d version(s)", providerAddr, len(versionsToRemove))
 	}
-	
+
 	// Update the provider list if we removed the entire provider
 	if shouldRemoveFromList {
 		mainLogger.Info(ctx, "Updating provider list...")

--- a/backend/cmd/remove/main.go
+++ b/backend/cmd/remove/main.go
@@ -246,6 +246,7 @@ func main() {
 			os.Exit(1)
 		}
 	} else {
+		// Handle individual version deletion
 		removed := map[provider.VersionNumber]struct{}{}
 		for _, v := range versionsToRemove {
 			// store the version we're removing
@@ -260,15 +261,28 @@ func main() {
 		}
 		providerData.Versions = filteredVersions
 
-		// store it
-		if err := providerStorage.StoreProvider(ctx, providerData); err != nil {
-			mainLogger.Error(ctx, "Failed to update provider index: %v", err)
-			os.Exit(1)
-		}
 		if len(providerData.Versions) == 0 {
+			// This was the last version, remove the provider entirely
 			shouldRemoveFromList = true
+			mainLogger.Info(ctx, "Removed last version of provider %s, removing provider entirely", providerAddr)
+
+			if err := providerStorage.DeleteProvider(ctx, providerAddr); err != nil {
+				mainLogger.Error(ctx, "Failed to remove provider: %v", err)
+				os.Exit(1)
+			}
+
+			if err := searchAPI.RemoveItem(ctx, searchtypes.IndexID("providers/"+providerAddr.String())); err != nil {
+				mainLogger.Error(ctx, "Failed to remove provider from search index: %v", err)
+				os.Exit(1)
+			}
+		} else {
+			// Rewrite the provider index without the removed version(s).
+			if err := providerStorage.StoreProvider(ctx, providerData); err != nil {
+				mainLogger.Error(ctx, "Failed to update provider index: %v", err)
+				os.Exit(1)
+			}
+			mainLogger.Info(ctx, "Updated provider %s index, removed %d version(s)", providerAddr, len(versionsToRemove))
 		}
-		mainLogger.Info(ctx, "Updated provider %s index, removed %d version(s)", providerAddr, len(versionsToRemove))
 	}
 
 	// Update the provider list if we removed the entire provider

--- a/backend/internal/providerindex/providerindexstorage/api_provider_version.go
+++ b/backend/internal/providerindex/providerindexstorage/api_provider_version.go
@@ -12,12 +12,6 @@ import (
 	"github.com/opentofu/registry-ui/internal/providerindex/providertypes"
 )
 
-func (s storage) getProviderVersionPath(providerAddr provider.Addr, version provider.VersionNumber) indexstorage.Path {
-	providerAddr = providerAddr.Normalize()
-	version = version.Normalize()
-	return indexstorage.Path(path.Join(providerAddr.Namespace, providerAddr.Name, string(version), providerAddr.Name))
-}
-
 func (s storage) getProviderVersionFile(providerAddr provider.Addr, version provider.VersionNumber) indexstorage.Path {
 	providerAddr = providerAddr.Normalize()
 	version = version.Normalize()
@@ -74,5 +68,8 @@ func (s storage) DeleteProviderVersion(ctx context.Context, providerAddr provide
 	if err := version.Validate(); err != nil {
 		return err
 	}
-	return s.indexStorageAPI.RemoveAll(ctx, s.getProviderVersionPath(providerAddr, version))
+	providerAddr = providerAddr.Normalize()
+	version = version.Normalize()
+	versionPath := indexstorage.Path(path.Join(providerAddr.Namespace, providerAddr.Name, string(version)))
+	return s.indexStorageAPI.RemoveAll(ctx, versionPath)
 }


### PR DESCRIPTION
The current v1 version of provider version deletion had two bugs, this PR fixes both

- Uses the correct path for deletion when deleting a provider version
- Stores the provider data index file back to r2 with the removed version

## Checklist

- [x] I have read the [contribution guide](https://github.com/opentofu/opentofu/blob/main/CONTRIBUTING.md).
- [x] I have not used an AI coding assistant to create this PR.
- [x] My contribution is compatible with the MPL-2.0 license and I have provided a DCO sign-off on all my commits.
- [x] I have written all code in this PR myself OR I have marked all code I have not written myself (including modified code, e.g. copied from other places and then modified) with a comment indicating where it came from.
